### PR TITLE
Implement error types, that are usefull for annotation processing

### DIFF
--- a/src/main/java/com/helger/jcodemodel/AbstractJType.java
+++ b/src/main/java/com/helger/jcodemodel/AbstractJType.java
@@ -135,6 +135,18 @@ public abstract class AbstractJType implements IJGenerable, IJOwned
   }
 
   /**
+   * Tells whether or not this is an error-type.
+   * <p>
+   * Error types are not actual Java types and shouldn't be used in actually generated code.
+   *
+   * @see JCodeModel#errorType(String)
+   */
+  public boolean isError ()
+  {
+    return false;
+  }
+
+  /**
    * If this class is a primitive type, return the boxed class. Otherwise return
    * <tt>this</tt>.
    * <p>
@@ -221,6 +233,8 @@ public abstract class AbstractJType implements IJGenerable, IJOwned
 
   protected boolean isAssignableFrom (final AbstractJType that, final boolean allowsRawTypeUnchekedConversion)
   {
+    if (isError () || that.isError ())
+      return false;
     if (this.equals (that))
       return true;
 

--- a/src/main/java/com/helger/jcodemodel/JCodeModel.java
+++ b/src/main/java/com/helger/jcodemodel/JCodeModel.java
@@ -282,6 +282,54 @@ public final class JCodeModel
   }
 
   /**
+   * Creates a dummy, error {@link AbstractJClass} that can only be referenced from hidden classes.
+   * <p>
+   * This method is useful when the code generation needs to include some error class
+   * that should never leak into actually written code.
+   * <p>
+   * Error-types represents holes or place-holders that can't be filled.
+   * References to error-classes can be used in hidden class-models.
+   * Such classes should never be actually written but can be somehow used during code generation.
+   * Use {@code JCodeModel#buildsErrorTypeRefs} method to test
+   * if your generated Java-sources contains references to error-types.
+   * <p>
+   * You should probably always check generated code with {@code JCodeModel#buildsErrorTypeRefs} method if
+   * you use any error-types.
+   * <p>
+   * Most of error-types methods throws {@code JErrorClassUsedException} unchecked exceptions.
+   * Be careful and use {@link AbstractJType#isError() AbstractJType#isError} method to check for error-types
+   * before actually using it's methods.
+   *
+   * @param message some free form text message to identify source of error
+   *
+   * @see JCodeModel#buildsErrorTypeRefs()
+   * @see JErrorClass
+   *
+   */
+  @Nonnull
+  public AbstractJClass errorClass (@Nonnull final String message)
+  {
+    return new JErrorClass (this, message);
+  }
+
+  /**
+   * Check if any error-types leaked into output Java-sources.
+   *
+   * @see JCodeModel#errorClass(String)
+   */
+  public boolean buildsErrorTypeRefs ()
+  {
+    final JPackage [] pkgs = _packages.values ().toArray (new JPackage [_packages.size ()]);
+    // avoid concurrent modification exception
+    for (final JPackage pkg : pkgs)
+    {
+      if (pkg.buildsErrorTypeRefs ())
+        return true;
+    }
+    return false;
+  }
+
+  /**
    * Gets a reference to the already created generated class.
    *
    * @return null If the class is not yet created.

--- a/src/main/java/com/helger/jcodemodel/JErrorClassUsedException.java
+++ b/src/main/java/com/helger/jcodemodel/JErrorClassUsedException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015 Philip Helger.
+ */
+package com.helger.jcodemodel;
+
+/**
+ *
+ * @author Victor Nazarov <asviraspossible@gmail.com>
+ */
+public class JErrorClassUsedException extends UnsupportedOperationException {
+  private static final long serialVersionUID = 1L;
+
+  JErrorClassUsedException (String message)
+  {
+    super (message);
+  }
+
+}

--- a/src/main/java/com/helger/jcodemodel/JNarrowedClass.java
+++ b/src/main/java/com/helger/jcodemodel/JNarrowedClass.java
@@ -256,6 +256,19 @@ public class JNarrowedClass extends AbstractJClass
   }
 
   @Override
+  public boolean isError ()
+  {
+    if (_basis.isError ())
+      return true;
+    for (final AbstractJClass aClass : _args)
+    {
+      if (aClass.isError ())
+        return true;
+    }
+    return false;
+  }
+
+  @Override
   public List <? extends AbstractJClass> getTypeParameters ()
   {
     return _args;

--- a/src/main/java/com/helger/jcodemodel/JPackage.java
+++ b/src/main/java/com/helger/jcodemodel/JPackage.java
@@ -565,6 +565,23 @@ public class JPackage implements IJDeclaration, IJGenerable, IJClassContainer, I
     }
   }
 
+  boolean buildsErrorTypeRefs ()
+  {
+    // check classes
+    for (final JDefinedClass c : _classes.values ())
+    {
+      if (c.isHidden ())
+      {
+        // don't check this file
+        continue;
+      }
+
+      if (JFormatter.containsErrorTypes(c))
+        return true;
+    }
+    return false;
+  }
+
   /* package */int countArtifacts ()
   {
     int ret = 0;

--- a/src/main/java/com/helger/jcodemodel/util/ClassNameComparator.java
+++ b/src/main/java/com/helger/jcodemodel/util/ClassNameComparator.java
@@ -45,6 +45,7 @@ import java.util.Comparator;
 import javax.annotation.Nonnull;
 
 import com.helger.jcodemodel.AbstractJClass;
+import com.helger.jcodemodel.JErrorClass;
 
 /**
  * Comparator object that sorts {@link AbstractJClass}es in the order of their
@@ -72,6 +73,13 @@ public final class ClassNameComparator implements Comparator <AbstractJClass>
    */
   public int compare (@Nonnull final AbstractJClass left, @Nonnull final AbstractJClass right)
   {
+    if (left.isError () && right.isError())
+      return 0;
+    if (left.isError ())
+      return -1;
+    if (right.isError ())
+      return +1;
+
     final String lhs = left.fullName ();
     final String rhs = right.fullName ();
     final boolean bLeftJava = lhs.startsWith ("java");

--- a/src/main/java/com/helger/jcodemodel/util/NullWriter.java
+++ b/src/main/java/com/helger/jcodemodel/util/NullWriter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 Philip Helger.
+ */
+package com.helger.jcodemodel.util;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ *
+ * @author Victor Nazarov <asviraspossible@gmail.com>
+ */
+public class NullWriter extends Writer {
+  private static final NullWriter INSTANCE = new NullWriter ();
+  
+  public static NullWriter getInstance ()
+  {
+    return INSTANCE;
+  }
+
+  private NullWriter ()
+  {
+  }
+
+  @Override
+  public void write (char[] cbuf, int off, int len) throws IOException
+  {
+  }
+
+  @Override
+  public void flush () throws IOException
+  {
+  }
+
+  @Override
+  public void close () throws IOException
+  {
+  }
+}


### PR DESCRIPTION
Error types are actually useful for code generation in annotation processors.

Error types corresponds to javax.lang.model.type.ErrorType used in Java-compiler.
