### PR TITLE
Feature error types

### DIFF
--- a/src/main/java/com/helger/jcodemodel/JFormatter.java
+++ b/src/main/java/com/helger/jcodemodel/JFormatter.java
@@ -577,19 +577,26 @@ public class JFormatter implements Closeable
     switch (m_eMode)
     {
       case COLLECTING:
-        final String sShortName = aType.name ();
-        NameUsage aUsages = m_aCollectedReferences.get (sShortName);
-        if (aUsages == null)
+        if (!aType.isError ())
         {
-          aUsages = new NameUsage (sShortName);
-          m_aCollectedReferences.put (sShortName, aUsages);
+          final String sShortName = aType.name ();
+          NameUsage aUsages = m_aCollectedReferences.get (sShortName);
+          if (aUsages == null)
+          {
+            aUsages = new NameUsage (sShortName);
+            m_aCollectedReferences.put (sShortName, aUsages);
+          }
+          aUsages.addReferencedType (aType);
         }
-        aUsages.addReferencedType (aType);
         break;
       case PRINTING:
         // many of the JTypes in this list are either primitive or belong to
         // package java so we don't need a FQCN
-        if (m_aImportedClasses.contains (aType) || aType._package () == m_aPckJavaLang)
+        if (aType.isError ())
+        {
+          print ("Object");
+        }
+        else if (m_aImportedClasses.contains (aType) || aType._package () == m_aPckJavaLang)
         {
           // FQCN imported or not necessary, so generate short name
           print (aType.name ());

--- a/src/main/java/com/helger/jcodemodel/meta/Annotator.java
+++ b/src/main/java/com/helger/jcodemodel/meta/Annotator.java
@@ -69,7 +69,7 @@ class Annotator
     this._typeEnvironment = typeEnvironment;
   }
 
-  void annotate (final List <? extends AnnotationMirror> annotationMirrors) throws CodeModelBuildingException
+  void annotate (final List <? extends AnnotationMirror> annotationMirrors) throws CodeModelBuildingException, IllegalStateException, ErrorTypeFound
   {
     for (final AnnotationMirror annotation : annotationMirrors)
     {
@@ -77,7 +77,7 @@ class Annotator
     }
   }
 
-  private void annotate (final AnnotationMirror annotation) throws CodeModelBuildingException, IllegalStateException
+  private void annotate (final AnnotationMirror annotation) throws CodeModelBuildingException, IllegalStateException, ErrorTypeFound
   {
     final JAnnotationUse annotationUse = _annotatable.annotate ((AbstractJClass) _modelsAdapter.toJType (annotation.getAnnotationType (),
                                                                                                          _typeEnvironment));
@@ -94,7 +94,7 @@ class Annotator
       this._annotationUse = annotationUse;
     }
 
-    void addArguments (final AnnotationMirror annotation) throws CodeModelBuildingException
+    void addArguments (final AnnotationMirror annotation) throws CodeModelBuildingException, IllegalStateException, ErrorTypeFound
     {
       final Map <? extends ExecutableElement, ? extends AnnotationValue> annotationArguments = _modelsAdapter.getElementValuesWithDefaults (annotation);
       for (final Map.Entry <? extends ExecutableElement, ? extends AnnotationValue> annotationValueAssignment : annotationArguments.entrySet ())
@@ -106,7 +106,8 @@ class Annotator
     }
 
     private void addArgument (final String name, final Object value) throws IllegalStateException,
-                                                                     CodeModelBuildingException
+                                                                     CodeModelBuildingException,
+                                                                     ErrorTypeFound
     {
       if (value instanceof String)
         _annotationUse.param (name, (String) value);

--- a/src/main/java/com/helger/jcodemodel/meta/ClassFiller.java
+++ b/src/main/java/com/helger/jcodemodel/meta/ClassFiller.java
@@ -66,7 +66,7 @@ class ClassFiller
     this._newClass = newClass;
   }
 
-  void fillClass (final TypeElement element, final TypeEnvironment environment) throws CodeModelBuildingException
+  void fillClass (final TypeElement element, final TypeEnvironment environment) throws CodeModelBuildingException, ErrorTypeFound
   {
     _newClass.hide ();
     final Annotator classAnnotator = new Annotator (_modelsAdapter, _newClass, environment);

--- a/src/main/java/com/helger/jcodemodel/meta/ErrorTypeFound.java
+++ b/src/main/java/com/helger/jcodemodel/meta/ErrorTypeFound.java
@@ -35,6 +35,7 @@ package com.helger.jcodemodel.meta;
 @SuppressWarnings ("serial")
 public class ErrorTypeFound extends Exception
 {
-  public ErrorTypeFound ()
-  {}
+  ErrorTypeFound(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/helger/jcodemodel/meta/ErrorTypePolicy.java
+++ b/src/main/java/com/helger/jcodemodel/meta/ErrorTypePolicy.java
@@ -1,0 +1,78 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.helger.jcodemodel.meta;
+
+/**
+ * Defines policy to use with error-types.
+ * <p>
+ * {@code tryBind} parameter provides access to
+ * (re-)binding of references to error-types.
+ * <p>
+ * We may use elements provided by Java compiler
+ * during jcodemodel code generation.
+ * Existing java source code may already have references to not yet generated classes.
+ * In such scenario Java-compiler will give us error-types.
+ * When this occures we may try to rebind error-types to classes defined
+ * in jcodemodel, but missing in existing Java source code accessible to Java-compiler.
+ * <p>
+ * When {@code tryBind} parameter is true, we try to rebind error-types to classes defined
+ * in jcodemodel.
+ * When {@code tryBind} parameter is false, error-types are returned as is.
+ *
+ * @author vir
+ */
+public class ErrorTypePolicy {
+  private final Action action;
+  private final boolean tryBind;
+
+  /**
+   * @see ErrorTypePolicy
+   *
+   * @param action
+   *        action to perform if any error-type is found.
+   * @param tryBind
+   *        if true try to (re-)bind references to error-types
+   *        to existing types.
+   */
+  public ErrorTypePolicy (Action action, boolean tryBind)
+  {
+    this.action = action;
+    this.tryBind = tryBind;
+  }
+
+  /**
+   * Action to perform if any error-type is found.
+   */
+  Action action ()
+  {
+    return action;
+  }
+
+  /**
+   * Try to rebind error-types to classes defined
+   * in jcodemodel.
+   * <p>
+   * We may use elements provided by Java compiler
+   * during jcodemodel code generation.
+   * Existing java source code may already have references to not yet generated classes.
+   * In such scenario Java-compiler will give us error-types.
+   * When this occures we may try to rebind error-types to classes defined
+   * in jcodemodel, but missing in existing Java source code accessible to Java-compiler.
+   * <p>
+   * When {@code tryBind} parameter is true, we try to rebind error-types to classes defined
+   * in jcodemodel.
+   * When {@code tryBind} parameter is false, error-types are returned as is.
+   * Action to perform if any error-type is found.
+   */
+  boolean tryBind ()
+  {
+    return tryBind;
+  }
+
+  public enum Action {
+    THROW_EXCEPTION, CREATE_ERROR_TYPE
+  }
+}

--- a/src/main/java/com/helger/jcodemodel/meta/JCodeModelJavaxLangModelAdapter.java
+++ b/src/main/java/com/helger/jcodemodel/meta/JCodeModelJavaxLangModelAdapter.java
@@ -34,6 +34,7 @@ import javax.lang.model.util.Elements;
 
 import com.helger.jcodemodel.JCodeModel;
 import com.helger.jcodemodel.JDefinedClass;
+import javax.annotation.Nonnull;
 
 public class JCodeModelJavaxLangModelAdapter
 {
@@ -43,7 +44,7 @@ public class JCodeModelJavaxLangModelAdapter
   /**
    * Creates new instance of JCodeModelJavaxLangModelAdapter.
    */
-  public JCodeModelJavaxLangModelAdapter (final JCodeModel codeModel, final Elements elementUtils)
+  public JCodeModelJavaxLangModelAdapter (@Nonnull final JCodeModel codeModel, @Nonnull final Elements elementUtils)
   {
     this._codeModel = codeModel;
     this._elementUtils = elementUtils;
@@ -54,23 +55,19 @@ public class JCodeModelJavaxLangModelAdapter
    *
    * @param element
    *        element to convert to class definition
+   * @return jcodemodel class definition for given element
    * @throws ErrorTypeFound
    *         if {@code element} argument contains references to so called
    *         "error"-types.
+   * @throws CodeModelBuildingException
+   *         when operation can't be performed.
+   *         For example, when given class already exists.
    */
-  public JDefinedClass getClass (final TypeElement element) throws ErrorTypeFound, CodeModelBuildingException
+  @Nonnull
+  public JDefinedClass getClass (@Nonnull final TypeElement element) throws ErrorTypeFound, CodeModelBuildingException
   {
-    final DecidedErrorTypesModelsAdapter errorTypeDecision = new DecidedErrorTypesModelsAdapter (_codeModel,
-                                                                                                 _elementUtils,
-                                                                                                 false);
-    try
-    {
-      return errorTypeDecision.getClass (element);
-    }
-    catch (final RuntimeErrorTypeFound ex)
-    {
-      throw ex.getCause ();
-    }
+    ErrorTypePolicy policy = new ErrorTypePolicy(ErrorTypePolicy.Action.THROW_EXCEPTION, true);
+    return getClass(element, policy);
   }
 
   /**
@@ -82,13 +79,48 @@ public class JCodeModelJavaxLangModelAdapter
    *
    * @param element
    *        element to convert to class definition
+   * @return jcodemodel class definition for given element.
+   * @throws CodeModelBuildingException
+   *         when operation can't be performed.
+   *         For example, when given class already exists.
    */
-  public JDefinedClass getClassWithErrorTypes (final TypeElement element) throws CodeModelBuildingException
+  @Nonnull
+  public JDefinedClass getClassWithErrorTypes (@Nonnull final TypeElement element) throws CodeModelBuildingException
+  {
+    ErrorTypePolicy policy = new ErrorTypePolicy(ErrorTypePolicy.Action.CREATE_ERROR_TYPE, true);
+      try {
+          return getClass(element, policy);
+      } catch (ErrorTypeFound ex) {
+          throw new RuntimeException("ErrorTypeFound exception is disabled and shouldn't be thrown here", ex);
+      }
+  }
+
+  /**
+   * Returns jcodemodel class definition for given element.
+   * <p>
+   * This method result-class definition can include references to
+   * "error"-types. Error-types are used only if they are present in
+   * {@code element} argument
+   *
+   * @param element
+   *        element to convert to class definition
+   * @param policy
+   *        error type policy
+   * @return jcodemodel class definition for given element.
+   * @throws ErrorTypeFound
+   *         if error type {@code policy} is configured to throw exceptions and
+   *         {@code element} argument contains references to so called
+   *         "error"-types
+   * @throws CodeModelBuildingException
+   *         when operation can't be performed.
+   *         For example, when given class already exists.
+   */
+  @Nonnull
+  public JDefinedClass getClass (@Nonnull final TypeElement element, @Nonnull ErrorTypePolicy policy) throws ErrorTypeFound, CodeModelBuildingException
   {
     final DecidedErrorTypesModelsAdapter errorTypeDecision = new DecidedErrorTypesModelsAdapter (_codeModel,
                                                                                                  _elementUtils,
-                                                                                                 true);
+                                                                                                 policy);
     return errorTypeDecision.getClass (element);
   }
-
 }

--- a/src/main/java/com/helger/jcodemodel/meta/TypeEnvironment.java
+++ b/src/main/java/com/helger/jcodemodel/meta/TypeEnvironment.java
@@ -41,15 +41,18 @@ class TypeEnvironment
 {
   private final Map <String, AbstractJType> map = new TreeMap <String, AbstractJType> ();
   private final TypeEnvironment _parent;
+  private final String _packageName;
 
-  TypeEnvironment ()
+  TypeEnvironment (final String packageName)
   {
     _parent = null;
+    _packageName = packageName;
   }
 
   private TypeEnvironment (final TypeEnvironment parent)
   {
-    this._parent = parent;
+    _packageName = null;
+    _parent = parent;
   }
 
   public TypeEnvironment enclosed ()
@@ -68,5 +71,9 @@ class TypeEnvironment
   public void put (final String name, final AbstractJType type)
   {
     map.put (name, type);
+  }
+
+  String packageName() {
+    return _parent == null ? _packageName : _parent.packageName();
   }
 }


### PR DESCRIPTION
Add rebinding of error types.
When java source code is processed by annotation processor it can contain references to not yet generated types. This references are represented with error types. This pull request allows to automatically bind error types to classes present in jcodemodel, but not outputted yet.