### PR TITLE
Store name in error type

### DIFF
--- a/src/main/java/com/helger/jcodemodel/JCodeModel.java
+++ b/src/main/java/com/helger/jcodemodel/JCodeModel.java
@@ -40,6 +40,12 @@
  */
 package com.helger.jcodemodel;
 
+import com.helger.jcodemodel.meta.CodeModelBuildingException;
+import com.helger.jcodemodel.meta.ErrorTypeFound;
+import com.helger.jcodemodel.meta.JCodeModelJavaxLangModelAdapter;
+import com.helger.jcodemodel.util.JCSecureLoader;
+import com.helger.jcodemodel.writer.FileCodeWriter;
+import com.helger.jcodemodel.writer.ProgressCodeWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -49,20 +55,12 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
-
-import com.helger.jcodemodel.meta.CodeModelBuildingException;
-import com.helger.jcodemodel.meta.ErrorTypeFound;
-import com.helger.jcodemodel.meta.JCodeModelJavaxLangModelAdapter;
-import com.helger.jcodemodel.util.JCSecureLoader;
-import com.helger.jcodemodel.writer.FileCodeWriter;
-import com.helger.jcodemodel.writer.ProgressCodeWriter;
 
 /**
  * Root of the code DOM.
@@ -365,9 +363,46 @@ public final class JCodeModel
    * @see JErrorClass
    */
   @Nonnull
-  public JErrorClass errorClass (@Nonnull final String sMessage)
+  public JErrorClass errorClass (
+    @Nonnull final String sMessage)
   {
-    return new JErrorClass (this, sMessage);
+    return errorClass (sMessage, null);
+  }
+
+  /**
+   * Creates a dummy, error {@link AbstractJClass} that can only be referenced
+   * from hidden classes.
+   * <p>
+   * This method is useful when the code generation needs to include some error
+   * class that should never leak into actually written code.
+   * <p>
+   * Error-types represents holes or place-holders that can't be filled.
+   * References to error-classes can be used in hidden class-models. Such
+   * classes should never be actually written but can be somehow used during
+   * code generation. Use {@code JCodeModel#buildsErrorTypeRefs} method to test
+   * if your generated Java-sources contains references to error-types.
+   * <p>
+   * You should probably always check generated code with
+   * {@code JCodeModel#buildsErrorTypeRefs} method if you use any error-types.
+   * <p>
+   * Most of error-types methods throws {@code JErrorClassUsedException}
+   * unchecked exceptions. Be careful and use {@link AbstractJType#isError()
+   * AbstractJType#isError} method to check for error-types before actually
+   * using it's methods.
+   *
+   * @param sName name of missing class if it is known
+   * @param sMessage
+   *        some free form text message to identify source of error
+   * @return New {@link JErrorClass}
+   * @see JCodeModel#buildsErrorTypeRefs()
+   * @see JErrorClass
+   */
+  @Nonnull
+  public JErrorClass errorClass (
+    @Nonnull final String sMessage,
+    @Nullable final String sName)
+  {
+    return new JErrorClass (this, sMessage, sName);
   }
 
   /**

--- a/src/main/java/com/helger/jcodemodel/JErrorClass.java
+++ b/src/main/java/com/helger/jcodemodel/JErrorClass.java
@@ -42,8 +42,8 @@ package com.helger.jcodemodel;
 
 import java.util.Iterator;
 import java.util.List;
-
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * A special {@link AbstractJClass} that represents an error class.
@@ -71,18 +71,28 @@ import javax.annotation.Nonnull;
 public class JErrorClass extends AbstractJClass
 {
   private final String m_sMessage;
+  private final String m_sName;
 
-  protected JErrorClass (@Nonnull final JCodeModel _owner, @Nonnull final String sMessage)
+  protected JErrorClass (
+    @Nonnull final JCodeModel _owner,
+    @Nonnull final String sMessage,
+    @Nullable final String sName)
   {
     super (_owner);
     m_sMessage = sMessage;
+    m_sName = sName;
+  }
+
+  protected JErrorClass (@Nonnull final JCodeModel _owner, @Nonnull final String sMessage)
+  {
+    this (_owner, sMessage, null);
   }
 
   @Override
-  @Nonnull
+  @Nullable
   public String name ()
   {
-    throw new JErrorClassUsedException (m_sMessage);
+    return m_sName;
   }
 
   @Override

--- a/src/main/java/com/helger/jcodemodel/meta/TypeMirrorToJTypeVisitor.java
+++ b/src/main/java/com/helger/jcodemodel/meta/TypeMirrorToJTypeVisitor.java
@@ -40,9 +40,13 @@
  */
 package com.helger.jcodemodel.meta;
 
+import com.helger.jcodemodel.AbstractJClass;
+import com.helger.jcodemodel.AbstractJType;
+import com.helger.jcodemodel.JCodeModel;
+import com.helger.jcodemodel.JDefinedClass;
+import com.helger.jcodemodel.JTypeWildcard;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
@@ -55,12 +59,6 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
 import javax.lang.model.type.WildcardType;
 import javax.lang.model.util.AbstractTypeVisitor6;
-
-import com.helger.jcodemodel.AbstractJClass;
-import com.helger.jcodemodel.AbstractJType;
-import com.helger.jcodemodel.JCodeModel;
-import com.helger.jcodemodel.JDefinedClass;
-import com.helger.jcodemodel.JTypeWildcard;
 
 /**
  * @author Victor Nazarov &lt;asviraspossible@gmail.com&gt;
@@ -161,8 +159,8 @@ class TypeMirrorToJTypeVisitor extends AbstractTypeVisitor6 <AbstractJType, Void
   public AbstractJType visitError (final ErrorType t, final Void p)
   {
     String typeName = t.asElement ().getSimpleName ().toString ();
-    typeName = _environment.packageName () + "." + typeName;
-    final JDefinedClass jCodeModelClass = _codeModel._getClass (typeName);
+    String fullTypeName = _environment.packageName () + "." + typeName;
+    final JDefinedClass jCodeModelClass = _codeModel._getClass (fullTypeName);
     if (jCodeModelClass != null)
     {
       final List <? extends TypeMirror> typeArguments = t.getTypeArguments ();
@@ -187,7 +185,7 @@ class TypeMirrorToJTypeVisitor extends AbstractTypeVisitor6 <AbstractJType, Void
       return jCodeModelClass.narrow (jArguments);
     }
     if (_errorTypePolicy.action () == ErrorTypePolicy.EAction.CREATE_ERROR_TYPE)
-      return _codeModel.errorClass (typeName + " in annotated source code");
+      return _codeModel.errorClass (typeName + " in annotated source code", typeName.equals ("<any>") ? null : typeName);
     try
     {
       throw new ErrorTypeFound (typeName + " in annotated source code");


### PR DESCRIPTION
Store simple name with error type.
This name is a name of type that is to be created/generated in order to fix error.
Missing type name is not always known, so this field is optional