### PR TITLE
Fix processing of nested annotation type declarations

### DIFF
--- a/src/main/java/com/helger/jcodemodel/meta/DecidedErrorTypesModelsAdapter.java
+++ b/src/main/java/com/helger/jcodemodel/meta/DecidedErrorTypesModelsAdapter.java
@@ -238,7 +238,8 @@ class DecidedErrorTypesModelsAdapter
     for (final Element enclosedElement : element.getEnclosedElements ())
     {
       if (enclosedElement.getKind ().equals (ElementKind.INTERFACE) ||
-          enclosedElement.getKind ().equals (ElementKind.CLASS))
+          enclosedElement.getKind ().equals (ElementKind.CLASS) ||
+          enclosedElement.getKind ().equals (ElementKind.ANNOTATION_TYPE))
       {
         final EClassType classType = toClassType (enclosedElement.getKind ());
         int modifiers = toJMod (enclosedElement.getModifiers ());


### PR DESCRIPTION
Allow meta-stuff to work with annotation type declarations defined as nested types.