### PR TITLE
Add scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,12 @@ Pull requests must follow my personal [Coding Styleguide](https://github.com/pha
 
 ### Tabs vs spaces
 
-This project uses double-space for indentation. If you want to use tabs, you can ask git to modify the files when commiting them and when pulling them. For this, from your project directory : 
+This project uses double-space for indentation. If you want to use tabs, you can ask git to modify the files when commiting them and when pulling them. A [specific script](sh/tabspaces) makes that chnage, run it from the root project.
 
- - edit the file .git/info/attributes to make it contain `*.java filter=tabspace` . This will tell git to apply the script tabspace on the *.java files
+
+What this script does  : 
+
+ - create the file .git/info/attributes with `*.java filter=tabspace` . This will tell git to apply the script tabspace on the *.java files
  - run `git config filter.tabspace.clean 'expand --tabs=2 --initial'` to ask git to replace tabs with two spaces on commit of *.java files.
  - run `git config filter.tabspace.smudge 'unexpand --tabs=2 --first-only'` to request git to replace double spaces with two tabs on checking a *.java file out.
 

--- a/sh/install
+++ b/sh/install
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# install the project locally
+
+mvn install -T2C -ntp

--- a/sh/tabspaces
+++ b/sh/tabspaces
@@ -1,0 +1,7 @@
+#!/bin//bash
+
+# change the local config to load java files with tabs, but commit them with spaces
+
+echo "*.java filter=tabspace" > .git/info/attributes               # tell git to apply the tabspace script on the *.java files
+git config filter.tabspace.clean 'expand --tabs=2 --initial'       # replace tabs with two spaces when commit of *.java files
+git config filter.tabspace.smudge 'unexpand --tabs=2 --first-only' # replace double spaces with two tabs when checking a *.java file out

--- a/sh/upgrades
+++ b/sh/upgrades
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# checks if there exists upgrade to the version specified on the root project. Does not make any change.
+# -ntp is to have No Transfer Progress ; -pl . means "project list : ."
+
+reset
+echo checking plugins on root module
+echo
+mvn -ntp versions:display-plugin-updates -pl .
+echo
+echo checking dependencies on root module
+echo
+mvn -ntp versions:display-dependency-updates -pl .


### PR DESCRIPTION
I added scripts to a new sh/ dir

1. `sh/install` runs maven install. This allows to have specific parameters for dev env, typically dev-specific profiles enabled.
2. `sh/upgrades` lists the possible upgrades to plugins and dependencies. It does NOT make any change to the actual project, only tells you some things exist.
3. ` sh/spacetabs` forces the git configuration that was explained in the readme, in order to commit java files with doublespace.

mvn params I use in those scripts : 
 - `-ntp` prevents flooding the logs with transfers when a server is slow/down. I got a project where the transfer progress was too verbose and above the logs limit, making the CI build unreadable.
 - `-T2C` tells maven to use twice the number of cores available for parallel modules building in the reactor. Especially important when lots of small submodules and you deploy them (so mix of local IO, remote IO and CPU usage)

Maybe later I will add a `sh/cores` that only install the core modules (not the examples, not the plugin) typically useful when adding a new feature on core and not willing to wait yet for full tests.