### PR TITLE
[WiP] git post-merge actions

### DIFF
--- a/.github/workflows/maven-postPR.yml
+++ b/.github/workflows/maven-postPR.yml
@@ -1,4 +1,4 @@
-name: Maven build
+name: Maven post-PR
 
 on:
   pull_request:
@@ -10,16 +10,13 @@ jobs:
   build:
     if: ${{ github.event.pull_request.merged }}
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [ 17, 21, 25 ]
-    name: Java ${{ matrix.java }} build
+    name: Java 17 post-process
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK ${{ matrix.java }}
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: ${{ matrix.java }}
+        java-version: 17
         distribution: 'adopt'
     - name: update versions
       run: mvn --batch-mode -ntp versions:set -DnewVersion=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)

--- a/.github/workflows/maven-postPR.yml
+++ b/.github/workflows/maven-postPR.yml
@@ -1,0 +1,30 @@
+name: Maven build
+
+on:
+  pull_request:
+    branches: 
+      - master
+    types: [closed]
+ 
+jobs:
+  build:
+    if: ${{ github.event.pull_request.merged }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 17, 21, 25 ]
+    name: Java ${{ matrix.java }} build
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v4
+      with:
+        java-version: ${{ matrix.java }}
+        distribution: 'adopt'
+    - name: update versions
+      run: mvn --batch-mode -ntp versions:set -DnewVersion=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+    - name: clean test
+      run: mvn --batch-mode -ntp clean install
+    - name: push changes
+      uses: stefanzweifel/git-auto-commit-action@v6
+        


### PR DESCRIPTION
Hello.

When I create a branch , then a PR, this branch is based on the version that was last when I branched. Let's say version A.

Later, the main repo master branch is released, and therefore given next version, version B.

If my PR incorporates new maven modules, those maven will be incorporated with version A on merging the PR, NOT with version B.

This means the tests on those modules will not take the recent changes into account. There may be bugs that won't be visible until a new release syncs the versions of those new module to a new one, say C.

This PR intend to avoid this : 
 - on new PR accepted only on the main repo.
 - use the maven versions plugin to retrieve the root version and apply it to the sub modules
 - call mvn clean install . This is because the classes generated by the sub modules could have been created with older code and therefore differ on a new build. clean ensures an error is not considered a pass due to last classes still wroking.
 - if any change AND pass, git commit -am "post-process git" && git push