### PR TITLE
using artifact name prefix convention

### DIFF
--- a/examples/plugins/csv/pom.xml
+++ b/examples/plugins/csv/pom.xml
@@ -25,7 +25,7 @@
   </parent>
   <groupId>com.helger.jcodemodel.examples.plugin</groupId>
   <artifactId>csv</artifactId>
-  <name>JCodeModel Example Generator CSV</name>
+  <name>XPL Generator CSV</name>
   <description>demonstrates and validates the usage of the jcodemodel plugin alongside the CSV generator</description>
 
   <build>

--- a/examples/plugins/helloworld/pom.xml
+++ b/examples/plugins/helloworld/pom.xml
@@ -25,7 +25,7 @@
   </parent>
   <groupId>com.helger.jcodemodel.examples.plugin</groupId>
   <artifactId>helloworld</artifactId>
-  <name>JCodeModel Example Generator HelloWorld</name>
+  <name>XPL Generator HelloWorld</name>
   <description>demonstrates and validates the usage of the jcodemodel plugin alongside the helloworld generator</description>
 
   <build>

--- a/examples/plugins/json/pom.xml
+++ b/examples/plugins/json/pom.xml
@@ -25,7 +25,7 @@
   </parent>
   <groupId>com.helger.jcodemodel.examples.plugin</groupId>
   <artifactId>json</artifactId>
-  <name>JCodeModel Example Generator JSON</name>
+  <name>XPL Generator JSON</name>
   <description>demonstrates and validates the usage of the jcodemodel plugin alongside the Json generator</description>
 
   <build>

--- a/examples/plugins/pom.xml
+++ b/examples/plugins/pom.xml
@@ -26,7 +26,7 @@
   <groupId>com.helger.jcodemodel.examples</groupId>
   <artifactId>plugins</artifactId>
   <packaging>pom</packaging>
-  <name>JCodeModel Examples Plugins Pom</name>
+  <name>POM Plugins Examples</name>
 
   <modules>
     <module>csv</module>

--- a/examples/plugins/yaml/pom.xml
+++ b/examples/plugins/yaml/pom.xml
@@ -25,7 +25,7 @@
   </parent>
   <groupId>com.helger.jcodemodel.examples.plugin</groupId>
   <artifactId>yaml</artifactId>
-  <name>JCodeModel Example Generator YAML</name>
+  <name>XPL Generator YAML</name>
   <description>demonstrates and validates the usage of the jcodemodel plugin alongside the YAML generator</description>
 
   <build>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -25,7 +25,7 @@
   </parent>
   <artifactId>examples</artifactId>
   <packaging>pom</packaging>
-  <name>JCodeModel Examples Pom</name>
+  <name>POM Examples</name>
   <description>POM module for all the examples modules</description>
 
   <modules>

--- a/plugin/generators/csv/pom.xml
+++ b/plugin/generators/csv/pom.xml
@@ -25,6 +25,6 @@
   </parent>
   <groupId>com.helger.jcodemodel.plugin.generators</groupId>
   <artifactId>csv</artifactId>
-  <name>JCodeModel Generator CSV</name>
+  <name>GEN CSV</name>
   <description>generates a structure tree from a csv file</description>
 </project>

--- a/plugin/generators/helloworld/pom.xml
+++ b/plugin/generators/helloworld/pom.xml
@@ -25,6 +25,6 @@
   </parent>
   <groupId>com.helger.jcodemodel.plugin.generators</groupId>
   <artifactId>helloworld</artifactId>
-  <name>JCodeModel Generator HelloWorld</name>
+  <name>GEN HelloWorld</name>
   <description>generates a simple class with a value</description>
 </project>

--- a/plugin/generators/json/pom.xml
+++ b/plugin/generators/json/pom.xml
@@ -25,7 +25,7 @@
   </parent>
   <groupId>com.helger.jcodemodel.plugin.generators</groupId>
   <artifactId>json</artifactId>
-  <name>JCodeModel Generator JSON</name>
+  <name>GEN JSON</name>
   <description>generates a structure tree from a json file</description>
   
   <dependencies>

--- a/plugin/generators/pom.xml
+++ b/plugin/generators/pom.xml
@@ -26,7 +26,7 @@
   <groupId>com.helger.jcodemodel.plugin</groupId>
   <artifactId>generators</artifactId>
   <packaging>pom</packaging>
-  <name>JCodeModel Generators Pom</name>
+  <name>POM Generators</name>
   <description>POM module for all the plugin-related codemodel generators</description>
 
   <modules>

--- a/plugin/generators/yaml/pom.xml
+++ b/plugin/generators/yaml/pom.xml
@@ -25,7 +25,7 @@
   </parent>
   <groupId>com.helger.jcodemodel.plugin.generators</groupId>
   <artifactId>yaml</artifactId>
-  <name>JCodeModel Generator YAML</name>
+  <name>GEN YAML</name>
   <description>generates a structure tree from a yaml file</description>
   <dependencies>
     <dependency>

--- a/plugin/plugin/pom.xml
+++ b/plugin/plugin/pom.xml
@@ -25,7 +25,7 @@
   </parent>
   <artifactId>jcodemodel-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <name>JCodeModel Maven Plugin</name>
+  <name>MVN JCodeModel Maven Plugin</name>
   <description>Maven plugin to generate classes using JCodeModel. This plugin requires a dedicated data loader to feed the JCodeModel the classes.</description>
 
   <dependencies>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -25,7 +25,7 @@
   </parent>
   <artifactId>plugin</artifactId>
   <packaging>pom</packaging>
-  <name>JCodeModel Plugins Pom</name>
+  <name>POM Plugins</name>
   <description>POM module for all the plugin-related modules</description>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <artifactId>jcodemodel-parent-pom</artifactId>
   <version>4.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <name>JCodeModel Parent POM</name>
+  <name>POM JCodeModel Parent</name>
   <description>Java code generation library parent POM</description>
   <url>https://github.com/phax/jcodemodel</url>
   <inceptionYear>2013</inceptionYear>


### PR DESCRIPTION
This is what it looks like with mvn clean install : 

[INFO] Reactor Summary for POM JCodeModel Parent 4.0.1-SNAPSHOT:
[INFO] 
[INFO] POM JCodeModel Parent .............................. SUCCESS [  0.204 s]
[INFO] JCodeModel ......................................... SUCCESS [  4.335 s]
[INFO] POM Plugins ........................................ SUCCESS [  0.009 s]
[INFO] MVN JCodeModel Maven Plugin ........................ SUCCESS [  1.184 s]
[INFO] POM Generators ..................................... SUCCESS [  0.005 s]
[INFO] GEN CSV ............................................ SUCCESS [  0.084 s]
[INFO] GEN HelloWorld ..................................... SUCCESS [  0.089 s]
[INFO] GEN JSON ........................................... SUCCESS [  0.108 s]
[INFO] GEN YAML ........................................... SUCCESS [  0.096 s]
[INFO] POM Examples ....................................... SUCCESS [  0.005 s]
[INFO] POM Plugins Examples ............................... SUCCESS [  0.006 s]
[INFO] XPL Generator HelloWorld ........................... SUCCESS [  0.286 s]
[INFO] XPL Generator CSV .................................. SUCCESS [  0.307 s]
[INFO] XPL Generator JSON ................................. SUCCESS [  0.191 s]
[INFO] XPL Generator YAML ................................. SUCCESS [  0.409 s]


and in eclipse : 

<img width="526" height="372" alt="image" src="https://github.com/user-attachments/assets/93bd7d35-17bb-4028-99ea-2a973559cfa4" />
