### PR TITLE
Add support for type-use annotations (TYPE_USE target) (JSR 308, Java 8+)

### DIFF
--- a/jcodemodel/src/main/java/com/helger/jcodemodel/AbstractJClass.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/AbstractJClass.java
@@ -40,6 +40,7 @@
  */
 package com.helger.jcodemodel;
 
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -315,6 +316,83 @@ public abstract class AbstractJClass extends AbstractJType
   public AbstractJClass narrowAny ()
   {
     return narrow (owner ().wildcard ());
+  }
+
+  /**
+   * Creates a new type with a type-use annotation (JSR 308, Java 8+).
+   * <p>
+   * This is different from {@link IJAnnotatable#annotate(Class)} which adds annotations to
+   * <em>declarations</em> (classes, methods, fields). This method creates a new <em>type</em>
+   * that includes the annotation, for use in contexts like generic type arguments.
+   * <p>
+   * <b>Comparison:</b>
+   * <pre>
+   * // Declaration annotation using annotate() - annotates the field itself:
+   * // Generates: @NotNull private List&lt;String&gt; items;
+   * field.annotate(NotNull.class);
+   *
+   * // Type-use annotation using annotated() - annotates the type argument:
+   * // Generates: private List&lt;@NotNull String&gt; items;
+   * cm.ref(List.class).narrow(cm.ref(String.class).annotated(NotNull.class));
+   * </pre>
+   * <p>
+   * <b>Example usage:</b>
+   * <pre>
+   * AbstractJClass itemClass = codeModel.ref(Item.class);
+   * AbstractJClass annotatedItem = itemClass.annotated(Valid.class);
+   * AbstractJClass listType = codeModel.ref(List.class).narrow(annotatedItem);
+   * // Generates: List&lt;@Valid Item&gt;
+   * </pre>
+   *
+   * @param aClazz
+   *        The annotation class to apply as a type-use annotation.
+   * @return A new {@link JAnnotatedClass} wrapping this class with the annotation.
+   * @since 4.2.0
+   * @see IJAnnotatable#annotate(Class) for adding annotations to declarations
+   */
+  @NonNull
+  public JAnnotatedClass annotated (@NonNull final Class <? extends Annotation> aClazz)
+  {
+    return annotated (owner ().ref (aClazz));
+  }
+
+  /**
+   * Creates a new type with a type-use annotation (JSR 308, Java 8+).
+   * <p>
+   * This is different from {@link IJAnnotatable#annotate(AbstractJClass)} which adds annotations to
+   * <em>declarations</em> (classes, methods, fields). This method creates a new <em>type</em>
+   * that includes the annotation, for use in contexts like generic type arguments.
+   * <p>
+   * <b>Comparison:</b>
+   * <pre>
+   * // Declaration annotation using annotate() - annotates the field itself:
+   * // Generates: @NotNull private List&lt;String&gt; items;
+   * field.annotate(NotNull.class);
+   *
+   * // Type-use annotation using annotated() - annotates the type argument:
+   * // Generates: private List&lt;@NotNull String&gt; items;
+   * cm.ref(List.class).narrow(cm.ref(String.class).annotated(NotNull.class));
+   * </pre>
+   * <p>
+   * <b>Example usage:</b>
+   * <pre>
+   * AbstractJClass itemClass = codeModel.ref(Item.class);
+   * AbstractJClass validAnnotation = codeModel.ref(Valid.class);
+   * AbstractJClass annotatedItem = itemClass.annotated(validAnnotation);
+   * AbstractJClass listType = codeModel.ref(List.class).narrow(annotatedItem);
+   * // Generates: List&lt;@Valid Item&gt;
+   * </pre>
+   *
+   * @param aClazz
+   *        The annotation class to apply as a type-use annotation.
+   * @return A new {@link JAnnotatedClass} wrapping this class with the annotation.
+   * @since 4.2.0
+   * @see IJAnnotatable#annotate(AbstractJClass) for adding annotations to declarations
+   */
+  @NonNull
+  public JAnnotatedClass annotated (@NonNull final AbstractJClass aClazz)
+  {
+    return new JAnnotatedClass (this, new JAnnotationUse (aClazz));
   }
 
   /**

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JAnnotatedClass.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JAnnotatedClass.java
@@ -1,0 +1,299 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 1997-2010 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright 2013-2025 Philip Helger + contributors
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package com.helger.jcodemodel;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import com.helger.base.enforce.ValueEnforcer;
+
+/**
+ * Represents a type with type-use annotations (Java 8+, JSR 308).
+ * <p>
+ * This class wraps an {@link AbstractJClass} and adds type-use annotations that are rendered
+ * directly before the type name. This enables generating code like:
+ * <pre>
+ * List&lt;@Valid Item&gt;
+ * Map&lt;@NonNull String, @Nullable Object&gt;
+ * </pre>
+ * <p>
+ * <b>Type-use annotations vs declaration annotations:</b>
+ * <ul>
+ * <li>{@link IJAnnotatable#annotate(Class)} adds annotations to <em>declarations</em> (the field,
+ * method, or class itself). Example: {@code @NotNull private List<String> items;}</li>
+ * <li>{@link AbstractJClass#annotated(Class)} creates a new <em>type</em> with embedded annotations.
+ * Example: {@code private List<@NotNull String> items;}</li>
+ * </ul>
+ * <p>
+ * Use {@link AbstractJClass#annotated(Class)} or {@link AbstractJClass#annotated(AbstractJClass)}
+ * to create instances of this class.
+ *
+ * @since 4.2.0
+ */
+public class JAnnotatedClass extends AbstractJClass
+{
+  /**
+   * The wrapped class that this annotation applies to.
+   */
+  private final AbstractJClass m_aBasis;
+
+  /**
+   * The type-use annotations to be rendered before the type.
+   */
+  private final List <JAnnotationUse> m_aAnnotations;
+
+  /**
+   * Creates a new annotated class with a single annotation.
+   *
+   * @param aBasis
+   *        The class to annotate. May not be <code>null</code>.
+   * @param aAnnotation
+   *        The annotation to apply. May not be <code>null</code>.
+   */
+  public JAnnotatedClass (@NonNull final AbstractJClass aBasis, @NonNull final JAnnotationUse aAnnotation)
+  {
+    this (aBasis, Collections.singletonList (aAnnotation));
+  }
+
+  /**
+   * Creates a new annotated class with multiple annotations.
+   *
+   * @param aBasis
+   *        The class to annotate. May not be <code>null</code>.
+   * @param aAnnotations
+   *        The annotations to apply. May not be <code>null</code> or empty.
+   */
+  public JAnnotatedClass (@NonNull final AbstractJClass aBasis, @NonNull final List <JAnnotationUse> aAnnotations)
+  {
+    super (aBasis.owner ());
+    ValueEnforcer.notNull (aBasis, "Basis");
+    ValueEnforcer.notEmpty (aAnnotations, "Annotations");
+    m_aBasis = aBasis;
+    m_aAnnotations = new ArrayList <> (aAnnotations);
+  }
+
+  /**
+   * @return The underlying class without annotations.
+   */
+  @NonNull
+  public AbstractJClass basis ()
+  {
+    return m_aBasis;
+  }
+
+  /**
+   * @return An unmodifiable list of annotations on this type.
+   */
+  @NonNull
+  public List <JAnnotationUse> annotations ()
+  {
+    return Collections.unmodifiableList (m_aAnnotations);
+  }
+
+  @Override
+  @NonNull
+  public JAnnotatedClass annotated (@NonNull final Class <? extends Annotation> aClazz)
+  {
+    return annotated (owner ().ref (aClazz));
+  }
+
+  @Override
+  @NonNull
+  public JAnnotatedClass annotated (@NonNull final AbstractJClass aClazz)
+  {
+    final List <JAnnotationUse> newAnnotations = new ArrayList <> (m_aAnnotations);
+    newAnnotations.add (new JAnnotationUse (aClazz));
+    return new JAnnotatedClass (m_aBasis, newAnnotations);
+  }
+
+  @Override
+  public String name ()
+  {
+    return m_aBasis.name ();
+  }
+
+  @Override
+  @NonNull
+  public String fullName ()
+  {
+    return m_aBasis.fullName ();
+  }
+
+  @Override
+  public String binaryName ()
+  {
+    return m_aBasis.binaryName ();
+  }
+
+  @Override
+  public JPackage _package ()
+  {
+    return m_aBasis._package ();
+  }
+
+  @Override
+  @Nullable
+  public AbstractJClass _extends ()
+  {
+    return m_aBasis._extends ();
+  }
+
+  @Override
+  @NonNull
+  public Iterator <AbstractJClass> _implements ()
+  {
+    return m_aBasis._implements ();
+  }
+
+  @Override
+  public boolean isInterface ()
+  {
+    return m_aBasis.isInterface ();
+  }
+
+  @Override
+  public boolean isAbstract ()
+  {
+    return m_aBasis.isAbstract ();
+  }
+
+  @Override
+  public boolean isArray ()
+  {
+    return m_aBasis.isArray ();
+  }
+
+  @Override
+  public boolean isError ()
+  {
+    return m_aBasis.isError ();
+  }
+
+  @Override
+  @Nullable
+  public JPrimitiveType getPrimitiveType ()
+  {
+    return m_aBasis.getPrimitiveType ();
+  }
+
+  @Override
+  @NonNull
+  public AbstractJClass erasure ()
+  {
+    return m_aBasis.erasure ();
+  }
+
+  @Override
+  public boolean containsTypeVar (@Nullable final JTypeVar aVar)
+  {
+    return m_aBasis.containsTypeVar (aVar);
+  }
+
+  @Override
+  @NonNull
+  public List <? extends AbstractJClass> getTypeParameters ()
+  {
+    return m_aBasis.getTypeParameters ();
+  }
+
+  @Override
+  @NonNull
+  public JTypeVar [] typeParams ()
+  {
+    return m_aBasis.typeParams ();
+  }
+
+  @Override
+  @Nullable
+  public AbstractJClass outer ()
+  {
+    return m_aBasis.outer ();
+  }
+
+  @Override
+  protected AbstractJClass substituteParams (@NonNull final JTypeVar [] aVariables,
+                                             @NonNull final List <? extends AbstractJClass> aBindings)
+  {
+    final AbstractJClass newBasis = m_aBasis.substituteParams (aVariables, aBindings);
+    if (newBasis == m_aBasis)
+      return this;
+    return new JAnnotatedClass (newBasis, m_aAnnotations);
+  }
+
+  @Override
+  public void generate (@NonNull final IJFormatter f)
+  {
+    for (final JAnnotationUse annotation : m_aAnnotations)
+    {
+      f.generable (annotation).print (' ');
+    }
+    f.type (m_aBasis);
+  }
+
+  @Override
+  void printLink (@NonNull final IJFormatter f)
+  {
+    m_aBasis.printLink (f);
+  }
+
+  @Override
+  public boolean equals (final Object obj)
+  {
+    if (obj == this)
+      return true;
+    if (obj == null || !getClass ().equals (obj.getClass ()))
+      return false;
+    final JAnnotatedClass that = (JAnnotatedClass) obj;
+    return m_aBasis.equals (that.m_aBasis) && m_aAnnotations.equals (that.m_aAnnotations);
+  }
+
+  @Override
+  public int hashCode ()
+  {
+    return m_aBasis.hashCode () * 37 + m_aAnnotations.hashCode ();
+  }
+}

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JAnnotatedClassTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JAnnotatedClassTest.java
@@ -1,0 +1,349 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 1997-2010 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright 2013-2025 Philip Helger + contributors
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package com.helger.jcodemodel;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.helger.jcodemodel.exceptions.JCodeModelException;
+import com.helger.jcodemodel.util.CodeModelTestsHelper;
+
+/**
+ * Unit tests for {@link JAnnotatedClass} - type-use annotation support.
+ */
+public final class JAnnotatedClassTest
+{
+  /**
+   * Test basic type-use annotation: {@code @Deprecated String}
+   */
+  @Test
+  public void testSimpleTypeAnnotation () throws JCodeModelException
+  {
+    final JCodeModel cm = JCodeModel.createUnified ();
+    final AbstractJClass stringClass = cm.ref (String.class);
+    final JAnnotatedClass annotatedString = stringClass.annotated (Deprecated.class);
+
+    assertNotNull (annotatedString);
+    assertEquals ("String", annotatedString.name ());
+    assertEquals ("java.lang.String", annotatedString.fullName ());
+    assertEquals (1, annotatedString.annotations ().size ());
+
+    // Check generated output
+    final String generated = CodeModelTestsHelper.generate (annotatedString);
+    assertEquals ("@java.lang.Deprecated java.lang.String", generated);
+
+    // Verify it parses when used in a class
+    final JDefinedClass testClass = cm._class ("com.example.Test");
+    testClass.field (JMod.PRIVATE, annotatedString, "value");
+    CodeModelTestsHelper.parseCodeModel (cm);
+  }
+
+  /**
+   * Test type-use annotation on generic type parameter: {@code java.util.List<@java.lang.Deprecated java.lang.String>}
+   */
+  @Test
+  public void testAnnotatedTypeParameter () throws JCodeModelException
+  {
+    final JCodeModel cm = JCodeModel.createUnified ();
+    final AbstractJClass stringClass = cm.ref (String.class);
+    final JAnnotatedClass annotatedString = stringClass.annotated (Deprecated.class);
+    final AbstractJClass listOfAnnotatedString = cm.ref (List.class).narrow (annotatedString);
+
+    // Check generated output
+    final String generated = CodeModelTestsHelper.generate (listOfAnnotatedString);
+    assertEquals ("java.util.List<@java.lang.Deprecated java.lang.String>", generated);
+
+    // Verify it parses when used in a class
+    final JDefinedClass testClass = cm._class ("com.example.Test");
+    testClass.field (JMod.PRIVATE, listOfAnnotatedString, "items");
+    CodeModelTestsHelper.parseCodeModel (cm);
+  }
+
+  /**
+   * Test multiple type-use annotations: {@code @Deprecated @Override String}
+   */
+  @Test
+  public void testMultipleTypeAnnotations () throws JCodeModelException
+  {
+    final JCodeModel cm = JCodeModel.createUnified ();
+    final AbstractJClass stringClass = cm.ref (String.class);
+    final JAnnotatedClass annotatedString = stringClass.annotated (Deprecated.class).annotated (Override.class);
+
+    assertEquals (2, annotatedString.annotations ().size ());
+
+    // Check generated output
+    final String generated = CodeModelTestsHelper.generate (annotatedString);
+    assertEquals ("@java.lang.Deprecated @java.lang.Override java.lang.String", generated);
+
+    // Verify it parses when used in a class
+    final JDefinedClass testClass = cm._class ("com.example.Test");
+    testClass.field (JMod.PRIVATE, annotatedString, "value");
+    CodeModelTestsHelper.parseCodeModel (cm);
+  }
+
+  /**
+   * Test annotated type with initializer.
+   */
+  @Test
+  public void testAnnotatedFieldWithInitializer () throws JCodeModelException
+  {
+    final JCodeModel cm = JCodeModel.createUnified ();
+    final JDefinedClass testClass = cm._class ("com.example.Test");
+
+    final AbstractJClass stringClass = cm.ref (String.class);
+    final JAnnotatedClass annotatedString = stringClass.annotated (Deprecated.class);
+    final AbstractJClass listType = cm.ref (List.class).narrow (annotatedString);
+    final AbstractJClass arrayListType = cm.ref (ArrayList.class).narrow (annotatedString);
+
+    testClass.field (JMod.PRIVATE, listType, "items", JExpr._new (arrayListType));
+
+    // Check the generated output contains the annotated type
+    final String classOutput = CodeModelTestsHelper.declare (testClass);
+    assertTrue ("Expected java.util.List<@java.lang.Deprecated java.lang.String> in output",
+                classOutput.contains ("java.util.List<@java.lang.Deprecated java.lang.String>"));
+
+    // Verify it parses
+    CodeModelTestsHelper.parseCodeModel (cm);
+  }
+
+  /**
+   * Test that erasure returns the underlying class without annotations.
+   */
+  @Test
+  public void testErasure () throws JCodeModelException
+  {
+    final JCodeModel cm = JCodeModel.createUnified ();
+    final AbstractJClass stringClass = cm.ref (String.class);
+    final JAnnotatedClass annotatedString = stringClass.annotated (Deprecated.class);
+
+    assertEquals (stringClass, annotatedString.erasure ());
+  }
+
+  /**
+   * Test that basis() returns the wrapped class.
+   */
+  @Test
+  public void testBasis () throws JCodeModelException
+  {
+    final JCodeModel cm = JCodeModel.createUnified ();
+    final AbstractJClass stringClass = cm.ref (String.class);
+    final JAnnotatedClass annotatedString = stringClass.annotated (Deprecated.class);
+
+    assertEquals (stringClass, annotatedString.basis ());
+  }
+
+  /**
+   * Test annotating an already narrowed class.
+   */
+  @Test
+  public void testAnnotateNarrowedClass () throws JCodeModelException
+  {
+    final JCodeModel cm = JCodeModel.createUnified ();
+
+    // Create List<String>
+    final AbstractJClass listOfString = cm.ref (List.class).narrow (String.class);
+
+    // Annotate the whole List<String> type
+    final JAnnotatedClass annotatedListOfString = listOfString.annotated (Deprecated.class);
+
+    // Check generated output
+    final String generated = CodeModelTestsHelper.generate (annotatedListOfString);
+    assertEquals ("@java.lang.Deprecated java.util.List<java.lang.String>", generated);
+
+    // Verify it parses when used in a class
+    final JDefinedClass testClass = cm._class ("com.example.Test");
+    testClass.field (JMod.PRIVATE, annotatedListOfString, "items");
+    CodeModelTestsHelper.parseCodeModel (cm);
+  }
+
+  /**
+   * Test complex nested annotations: {@code Map<@A String, List<@B Integer>>}
+   */
+  @Test
+  public void testNestedAnnotatedTypes () throws JCodeModelException
+  {
+    final JCodeModel cm = JCodeModel.createUnified ();
+
+    // @Deprecated String
+    final JAnnotatedClass annotatedString = cm.ref (String.class).annotated (Deprecated.class);
+
+    // @Override Integer
+    final JAnnotatedClass annotatedInteger = cm.ref (Integer.class).annotated (Override.class);
+
+    // List<@Override Integer>
+    final AbstractJClass listOfAnnotatedInteger = cm.ref (List.class).narrow (annotatedInteger);
+
+    // Map<@Deprecated String, List<@Override Integer>>
+    final AbstractJClass mapType = cm.ref (java.util.Map.class).narrow (annotatedString, listOfAnnotatedInteger);
+
+    // Check generated output
+    final String generated = CodeModelTestsHelper.generate (mapType);
+    assertEquals ("java.util.Map<@java.lang.Deprecated java.lang.String, java.util.List<@java.lang.Override java.lang.Integer>>",
+                  generated);
+
+    // Verify it parses when used in a class
+    final JDefinedClass testClass = cm._class ("com.example.Test");
+    testClass.field (JMod.PRIVATE, mapType, "data");
+    CodeModelTestsHelper.parseCodeModel (cm);
+  }
+
+  /**
+   * Test that the annotated class works correctly in method parameters.
+   */
+  @Test
+  public void testAnnotatedMethodParameter () throws JCodeModelException
+  {
+    final JCodeModel cm = JCodeModel.createUnified ();
+    final JDefinedClass testClass = cm._class ("com.example.Test");
+
+    final AbstractJClass stringClass = cm.ref (String.class);
+    final JAnnotatedClass annotatedString = stringClass.annotated (Deprecated.class);
+    final AbstractJClass listType = cm.ref (List.class).narrow (annotatedString);
+
+    final JMethod method = testClass.method (JMod.PUBLIC, cm.VOID, "process");
+    method.param (listType, "items");
+
+    // Check the generated output contains the annotated type in parameter
+    final String classOutput = CodeModelTestsHelper.declare (testClass);
+    assertTrue ("Expected java.util.List<@java.lang.Deprecated java.lang.String> in method parameter",
+                classOutput.contains ("java.util.List<@java.lang.Deprecated java.lang.String> items"));
+
+    // Verify it parses
+    CodeModelTestsHelper.parseCodeModel (cm);
+  }
+
+  /**
+   * Test that the annotated class works correctly as method return type.
+   */
+  @Test
+  public void testAnnotatedReturnType () throws JCodeModelException
+  {
+    final JCodeModel cm = JCodeModel.createUnified ();
+    final JDefinedClass testClass = cm._class ("com.example.Test");
+
+    final AbstractJClass stringClass = cm.ref (String.class);
+    final JAnnotatedClass annotatedString = stringClass.annotated (Deprecated.class);
+    final AbstractJClass listType = cm.ref (List.class).narrow (annotatedString);
+
+    final JMethod method = testClass.method (JMod.PUBLIC, listType, "getItems");
+    method.body ()._return (JExpr._null ());
+
+    // Check the generated output contains the annotated return type
+    final String classOutput = CodeModelTestsHelper.declare (testClass);
+    assertTrue ("Expected java.util.List<@java.lang.Deprecated java.lang.String> as return type",
+                classOutput.contains ("java.util.List<@java.lang.Deprecated java.lang.String> getItems()"));
+
+    // Verify it parses
+    CodeModelTestsHelper.parseCodeModel (cm);
+  }
+
+  /**
+   * Test equals and hashCode - two annotated classes with same basis and annotations should be equal.
+   */
+  @Test
+  public void testEqualsAndHashCode () throws JCodeModelException
+  {
+    final JCodeModel cm = JCodeModel.createUnified ();
+    final AbstractJClass stringClass = cm.ref (String.class);
+
+    final JAnnotatedClass annotated1 = stringClass.annotated (Deprecated.class);
+    final JAnnotatedClass annotated2 = stringClass.annotated (Deprecated.class);
+    final JAnnotatedClass annotated3 = stringClass.annotated (Override.class);
+
+    // Same basis and same annotation class should produce equivalent results
+    assertEquals (annotated1.basis (), annotated2.basis ());
+    assertEquals (annotated1.annotations ().size (), annotated2.annotations ().size ());
+
+    // Different annotations should not be equal
+    assertFalse (annotated1.equals (annotated3));
+  }
+
+  /**
+   * Test annotated array type: {@code @Deprecated String[]}
+   */
+  @Test
+  public void testAnnotatedArrayType () throws JCodeModelException
+  {
+    final JCodeModel cm = JCodeModel.createUnified ();
+
+    // @Deprecated String[]
+    final AbstractJClass stringArray = cm.ref (String.class).array ();
+    final JAnnotatedClass annotatedArray = stringArray.annotated (Deprecated.class);
+
+    // Check generated output
+    final String generated = CodeModelTestsHelper.generate (annotatedArray);
+    assertEquals ("@java.lang.Deprecated java.lang.String[]", generated);
+
+    // Verify it parses when used in a class
+    final JDefinedClass testClass = cm._class ("com.example.Test");
+    testClass.field (JMod.PRIVATE, annotatedArray, "items");
+    CodeModelTestsHelper.parseCodeModel (cm);
+  }
+
+  /**
+   * Test annotated primitive array type: {@code @Deprecated int[]}
+   */
+  @Test
+  public void testAnnotatedPrimitiveArrayType () throws JCodeModelException
+  {
+    final JCodeModel cm = JCodeModel.createUnified ();
+
+    // @Deprecated int[]
+    final JArrayClass intArray = cm.INT.array ();
+    final JAnnotatedClass annotatedIntArray = intArray.annotated (Deprecated.class);
+
+    // Check generated output
+    final String generated = CodeModelTestsHelper.generate (annotatedIntArray);
+    assertEquals ("@java.lang.Deprecated int[]", generated);
+
+    // Verify it parses when used in a class
+    final JDefinedClass testClass = cm._class ("com.example.Test");
+    testClass.field (JMod.PRIVATE, annotatedIntArray, "values");
+    CodeModelTestsHelper.parseCodeModel (cm);
+  }
+}


### PR DESCRIPTION
Adds JAnnotatedClass which wraps an AbstractJClass with type-use annotations, enabling code generation like List<@Valid Item>.

Usage:
  AbstractJClass annotatedItem = itemClass.annotated(Valid.class);
  AbstractJClass listType = cm.ref(List.class).narrow(annotatedItem);

Addresses phax/jcodemodel#50