### PR TITLE
generated/javatests licenses

### DIFF
--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/basic/Simple1.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/basic/Simple1.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
 package com.helger.jcodemodel.tests.basic;
 
 public class Simple1 {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/basic/Simple2.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/basic/Simple2.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
 package com.helger.jcodemodel.tests.basic;
 
 public class Simple2 {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/basic/Simple3.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/basic/Simple3.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
 package com.helger.jcodemodel.tests.basic;
 
 public class Simple3 {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/AnnotatedPerson.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/AnnotatedPerson.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
 package com.helger.jcodemodel.tests.record;
 
 public record AnnotatedPerson(@JRecordTestGen.RecordAnnotationExample String name, int age) {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/ArrayRecord.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/ArrayRecord.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
 package com.helger.jcodemodel.tests.record;
 
 public record ArrayRecord(String[] names, int[][] matrix) {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/BasicPoint.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/BasicPoint.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
 package com.helger.jcodemodel.tests.record;
 
 public record BasicPoint(int x, int y) {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/Empty.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/Empty.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
 package com.helger.jcodemodel.tests.record;
 
 public record Empty() {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/NamedPoint.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/NamedPoint.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
 package com.helger.jcodemodel.tests.record;
 
 public record NamedPoint(int x, int y, String name)

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/Outer.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/Outer.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
 package com.helger.jcodemodel.tests.record;
 
 public class Outer {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/Pair.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/Pair.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
 package com.helger.jcodemodel.tests.record;
 
 public record Pair<T, U>(T first, U second) {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/PairNumber.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/PairNumber.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
 package com.helger.jcodemodel.tests.record;
 
 public record PairNumber<T extends Number>(T first, T second) {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/Person.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/Person.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
 package com.helger.jcodemodel.tests.record;
 
 public record Person(String name, Integer age) {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/PointDistance.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/PointDistance.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
 package com.helger.jcodemodel.tests.record;
 
 public record PointDistance(int x, int y) {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/PointJavadoc.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/PointJavadoc.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
 package com.helger.jcodemodel.tests.record;
 
 

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/PointStatic.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/PointStatic.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
 package com.helger.jcodemodel.tests.record;
 
 public record PointStatic(int x, int y) {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/Range.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/Range.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
 package com.helger.jcodemodel.tests.record;
 
 public record Range(int lo, int hi) {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/RangeCanonical.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/RangeCanonical.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
 package com.helger.jcodemodel.tests.record;
 
 public record RangeCanonical(int lo, int hi) {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/SeriesVarArgs.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/SeriesVarArgs.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
 package com.helger.jcodemodel.tests.record;
 
 public record SeriesVarArgs(String name, int... values) {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/unnamed/SimpleUnnamed.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/unnamed/SimpleUnnamed.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
 package com.helger.jcodemodel.tests.unnamed;
 
 public class SimpleUnnamed {

--- a/jcodemodeltests/src/main/java/com/helger/jcodemodel/compile/annotation/GenerateTestFiles.java
+++ b/jcodemodeltests/src/main/java/com/helger/jcodemodel/compile/annotation/GenerateTestFiles.java
@@ -35,6 +35,20 @@ public class GenerateTestFiles {
 
   private static final String CLASS_SCAN_DIR = "src/main/java";
 
+  private static final String LICENCE = """
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+""";
+
   private final File outputDir;
 
   private final File classScanDir;
@@ -168,11 +182,22 @@ public class GenerateTestFiles {
             }
           }
           if (produced != null) {
+            postProcessJCM(produced);
             new JCMWriter(produced).build(outputDir, (IProgressTracker) null);
           }
         }
       }
     }
+  }
+
+  protected void postProcessJCM(JCodeModel jcm) {
+    jcm.getAllPackages().stream()
+        .flatMap(jp -> jp.classes().stream())
+        .filter(jdc -> !jdc.isHidden())
+        .filter(jdc -> !jdc.hasHeaderComment())
+        .forEach(jdc -> {
+          jdc.headerComment().add(LICENCE);
+        });
   }
 
 }


### PR DESCRIPTION
Small fix to add the licence so the generated class files.
Copied from the JCMWriter to dicover the classes from the packages

 - lists the classes of the packages
 - hidden classes are discarded
 - classes with already a header are discarded (even if empty header)
 - subclasses are not walked over.
 - add the header LICENCE to the selected classes.

@phax  I let you change what needs change.
maybe run sh/cleaninstal before merging ?