### PR TITLE
java9 : concise try with resource

### DIFF
--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JTryBlock.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JTryBlock.java
@@ -67,6 +67,37 @@ public class JTryBlock implements IJStatement
   {
     return m_aResources;
   }
+  
+  /// add an existing var to be closed as a resource 
+  ///  @return this, for ease of chaining.
+  public JTryBlock withResource(JVar avar)
+  {
+    tryResources().add(new JTryResource(avar));
+    return this;
+  }	
+  
+  /// create a new variable to be closed as a resource
+  /// 
+  ///  @return the created variable.
+  public JVar withResource(@NonNull final AbstractJType aType, @NonNull final String sName, @NonNull final IJExpression aInitExpr)
+  {
+    JTryResource resource = new JTryResource(aType, sName, aInitExpr);
+    tryResources().add(resource);
+    return resource.var();
+  }
+  
+  /// create a new variable to be closed as a resource
+  /// 
+  ///  @return the created variable.
+  public JVar withResource(final int nMods,
+                       @NonNull final AbstractJType aType,
+                       @NonNull final String sName,
+                       @NonNull final IJExpression aInitExpr)
+  {
+    JTryResource resource = new JTryResource(nMods, aType, sName, aInitExpr);
+    tryResources().add(resource);
+    return resource.var();
+  }
 
   /**
    * @return The non-<code>null</code> try-body.

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JTryResource.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JTryResource.java
@@ -52,6 +52,9 @@ import org.jspecify.annotations.NonNull;
 public class JTryResource implements IJGenerable
 {
   private final JVar m_aVar;
+  
+  /// when set to true, the jvar is already defined and should only be *generated*
+  private final boolean reuse;
 
   public JTryResource (@NonNull final AbstractJType aType, @NonNull final String sName, @NonNull final IJExpression aInitExpr)
   {
@@ -64,6 +67,13 @@ public class JTryResource implements IJGenerable
                        @NonNull final IJExpression aInitExpr)
   {
     m_aVar = new JVar (JMods.forVar (nMods), aType, sName, aInitExpr);
+    reuse=false;
+  }
+  
+  public JTryResource(JVar avar)
+  {
+    this.m_aVar=avar;
+    reuse=true;
   }
 
   @NonNull
@@ -74,6 +84,9 @@ public class JTryResource implements IJGenerable
 
   public void generate (@NonNull final IJFormatter aFormatter)
   {
-    aFormatter.var (m_aVar);
+    if(reuse)
+      aFormatter.generable(m_aVar);
+    else 
+      aFormatter.var (m_aVar);
   }
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/tryresource/BasicTry.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/tryresource/BasicTry.java
@@ -1,0 +1,9 @@
+package com.helger.jcodemodel.tests.tryresource;
+
+public class BasicTry {
+
+    public void close(ConciseTryTestGen.NoErrorCloseable p) {
+        try(p) {
+        }
+    }
+}

--- a/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/tryresource/ConciseTryTestGen.java
+++ b/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/tryresource/ConciseTryTestGen.java
@@ -1,0 +1,29 @@
+package com.helger.jcodemodel.tests.tryresource;
+
+import com.helger.jcodemodel.JCodeModel;
+import com.helger.jcodemodel.JDefinedClass;
+import com.helger.jcodemodel.JMethod;
+import com.helger.jcodemodel.JMod;
+import com.helger.jcodemodel.JPackage;
+import com.helger.jcodemodel.JVar;
+import com.helger.jcodemodel.compile.annotation.TestJCM;
+import com.helger.jcodemodel.exceptions.JCodeModelException;
+
+@TestJCM
+public class ConciseTryTestGen {
+
+  public interface NoErrorCloseable extends AutoCloseable {
+
+    /// doesn't throw an ioexception
+    @Override
+    void close();
+  }
+
+  public void basicTry(JPackage root, JCodeModel jcm) throws JCodeModelException {
+    JDefinedClass cl = root._class("BasicTry");
+    JMethod m = cl.method(JMod.PUBLIC, jcm.VOID, "close");
+    JVar p = m.param(NoErrorCloseable.class, "p");
+    m.body()._try().withResource(p);
+  }
+
+}

--- a/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/tryresource/ConciseTryTest.java
+++ b/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/tryresource/ConciseTryTest.java
@@ -1,0 +1,28 @@
+package com.helger.jcodemodel.tests.tryresource;
+
+import org.junit.Test;
+
+import com.helger.jcodemodel.tests.tryresource.ConciseTryTestGen.NoErrorCloseable;
+
+public class ConciseTryTest {
+
+  public class CloseMemory implements NoErrorCloseable {
+
+    public int closed = 0;
+
+    @Override
+    public void close() {
+      closed++;
+    }
+
+  }
+
+  @Test
+  public void testConciseTry() {
+    CloseMemory cm = new CloseMemory();
+    org.junit.Assert.assertEquals(0, cm.closed);
+    new BasicTry().close(cm);
+    org.junit.Assert.assertEquals(1, cm.closed);
+  }
+
+}


### PR DESCRIPTION
Java 9 added more concise try-with-resource, allowing to use an existing variable to be closed as a resource.

```java
AutoCloseable ac;
try(ac){}
```

This PR adds the following

# JTryResource reuse

Add the private final boolean `reuse` to JTryResource. When set to true on constructor, the internal JVar is *generated* instead of *variated* upon the jresource's generation.

A constructor from an existing jvar is added, that sets that field to true. previous constructors now set it to false.

# Syntaxic sugar methods

Add 3 `withResource(…)` sugar methods in JTryBlock. Those methods directly call the different constructors for JTryResource and add the new constructed jresource internally.

The 2 methods that create a new JVar return that new JVar, the one that reuses an existing jvar returns `this` to allow chaining.

# Minimal tests

A single minimal test is present, ready to be extended for specific issues.