### PR TITLE
Transmit Java Feature

### DIFF
--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JExpr.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JExpr.java
@@ -40,6 +40,8 @@
  */
 package com.helger.jcodemodel;
 
+import java.util.stream.Stream;
+
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -503,6 +505,15 @@ public final class JExpr
   public static JStringLiteral lit (@NonNull final String sStr)
   {
     return new JStringLiteral (sStr);
+  }
+  
+  @NonNull
+  public static JTextBlock textBlock (@NonNull final String ... lines)
+  {
+    JTextBlock ret = new JTextBlock();
+    if(lines!=null && lines.length!=0)
+      Stream.of(lines).forEach(ret::add);
+    return ret;
   }
 
   /**

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
@@ -1,0 +1,268 @@
+package com.helger.jcodemodel;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import com.helger.annotation.Nonnegative;
+import com.helger.base.enforce.ValueEnforcer;
+import com.helger.base.string.StringReplace;
+import com.helger.cache.regex.RegExHelper;
+
+/// Represents a text block declaration, one line at a time.
+///
+/// ## Main usage
+///
+/// This class produces java text blocks in the generated source file.
+/// It is used by adding lines to it, either one at a time or by passing multiline-string.
+/// The added lines are split by newline separator, then double quotes are escaped when needed.
+/// The [#keepWhiteSpaces] property specifies whether the string added are the one in the *file* (default), or in the resulting *String*.
+///
+/// ## Indenting
+///
+/// The [#indentSize] and [#indentChar] (by default size 0 and char space) specify which indentation is to be *added* at the beginning of each line.
+/// Note that if the last line is not empty, then the *source* output will have requested indent but the *produced* String will have space indentation even when [indentChar] is set to tab.
+///
+/// ## Double quote escaping
+///
+/// triple doublequotes `"""` are escaped by having the third one backslashed `""\"`.
+/// Plus, if the last line ends with an unescaped doublequote, this doublequote is escaped to avoid breaking the parser.
+///
+/// ## Property keepWhiteSpaces
+///
+/// The produced lines differ depending on [#keepWhitespaces]
+///  - when false(default), the content of the **file** will be the one added.
+///    Adding ` a ` will result in the textblock containing it, thus the resulting line will be `a` because of whitespaces strupping in textblocks
+///  - when true, the content of the **parsed string** will be the one added.
+///    Adding `  a  ` will result in the textblock containing instead `\040 a \040` to ensure the parsed string will be `  a  `.
+/// In the later, if all lines start with a whitespace, then the first character is set to octal ; plus all line-ending whitespace are also set to octal.
+///
+///
+/// [https://docs.oracle.com/en/java/javase/26/language/text-blocks.html]
+/// @author Guillaume Le Louët (guillaume.lelouet@gmail.com)
+///
+public class JTextBlock implements IJExpression, Iterable <String>
+{
+  private static final String LIMITER = "\"\"\"";
+
+  private char indentChar = ' ';
+  private int indentSize = 0;
+  private final List <String> lines = new ArrayList <> ();
+  private boolean keepWhitespaces = false;
+
+  public JTextBlock ()
+  {}
+
+  public JTextBlock (final @Nullable String value)
+  {
+    add (value);
+  }
+
+  /// convert a user line into several individual text block lines.
+  static @NonNull Stream <String> formatLines (final @NonNull String line)
+  {
+    return line.lines ().map (JTextBlock::formatLine);
+  }
+
+  /// format a standard String line to make it a text block line.
+  static @Nullable String formatLine (final @Nullable String line)
+  {
+    // escape triple parenthesis
+    return StringReplace.replaceAll (line, "\"\"\"", "\"\"\\\"");
+  }
+
+  static @Nullable String escapeLastIfDoubleQuote (final @Nullable String s)
+  {
+    if (s == null)
+      return null;
+    if (s.equals ("\""))
+      return "\\\"";
+    return RegExHelper.stringReplacePattern ("([^\\\\])\"$", s, "$1\\\\\"");
+  }
+
+  /// @return this, to chain
+  public @Nonnegative int indentSize ()
+  {
+    return indentSize;
+  }
+
+  /// @return this, to chain
+  public @NonNull JTextBlock indentSize (final @Nonnegative int val)
+  {
+    ValueEnforcer.isGE0 (val, "IndentSize");
+    indentSize = val;
+    return this;
+  }
+
+  /// @return this, to chain
+  public char indentChar ()
+  {
+    return indentChar;
+  }
+
+  /// @return this, to chain
+  public @NonNull JTextBlock indentChar (final char val)
+  {
+    if (val != ' ' && val != '\t')
+      throw new IllegalArgumentException ("escape char must be space or tab");
+
+    indentChar = val;
+    return this;
+  }
+
+  /// @return this, to chain
+  public @NonNull JTextBlock indentSpace ()
+  {
+    return indentChar (' ');
+  }
+
+  /// @return this, to chain
+  public @NonNull JTextBlock indentTab ()
+  {
+    return indentChar ('\t');
+  }
+
+  public boolean keepWhitespaces ()
+  {
+    return keepWhitespaces;
+  }
+
+  /// @return this, to chain
+  public @NonNull JTextBlock keepWhitespaces (final boolean verbatim)
+  {
+    keepWhitespaces = verbatim;
+    return this;
+  }
+
+  ///
+  /// transforms a line to make it fit to the text block syntax.
+  ///
+  /// @param line if null nothing happens
+  /// @return this, to chain
+  public @NonNull JTextBlock add (final @Nullable String line)
+  {
+    if (line != null)
+      formatLines (line).forEach (lines::add);
+
+    return this;
+  }
+
+  /// shortcut to add an empty line
+  /// @return this, to chain
+  public @NonNull JTextBlock newline ()
+  {
+    lines.add ("");
+    return this;
+  }
+
+  /// shortcut to add empty lines
+  /// @param nb when <1 nothing happens
+  /// @return this, to chain
+  public @NonNull JTextBlock newlines (final int nb)
+  {
+    for (int i = 0; i < nb; i++)
+      newline ();
+
+    return this;
+  }
+
+  /// unmodifiable iterator over the internal lines
+  public @NonNull Iterator <String> iterator ()
+  {
+    return Collections.unmodifiableList (lines).iterator ();
+  }
+
+  public @NonNull Stream <String> lines ()
+  {
+    return lines.stream ();
+  }
+
+  public void generate (@NonNull final IJFormatter f)
+  {
+    f.print (LIMITER).newline ();
+    final String indent = indentSize <= 0 || lines.isEmpty () ? ""
+                                                              : Character.toString (indentChar).repeat (indentSize);
+    boolean firstLine = true;
+    boolean lastEmpty = true;
+    // don't modify the internal list : work on a copy if modification required.
+    List <String> modifiedLines = lines;
+    // the last line must not end with unescaped doublequote
+    // if that's the case, we copy the full list to not modify the existing one.
+    if (!modifiedLines.isEmpty ())
+    {
+      final String lastLine = modifiedLines.get (modifiedLines.size () - 1);
+      final String escapedLastLine = escapeLastIfDoubleQuote (lastLine);
+      if (!escapedLastLine.equals (lastLine))
+      {
+        modifiedLines = new ArrayList <> (lines);
+        modifiedLines.set (modifiedLines.size () - 1, escapedLastLine);
+      }
+    }
+
+    boolean escapeFirstChar = requiresEscapeFirstChar (keepWhitespaces, modifiedLines);
+    // if (keepWhitespaces) {
+    // System.err.println("escapefirst " + escapeFirstChar + " from " + modifiedLines);
+    // }
+
+    for (String line : modifiedLines)
+    {
+      if (!firstLine)
+        f.newline ();
+
+      if (escapeFirstChar && !line.isEmpty ())
+      {
+        // replace starting space/tab by octal
+        line = RegExHelper.stringReplacePattern ("^ ", line, "\\\\s");
+        line = RegExHelper.stringReplacePattern ("^\t", line, "\\\\t");
+        escapeFirstChar = false;
+      }
+      if (keepWhitespaces)
+      {
+        // replace ending space/tab by octal
+        line = RegExHelper.stringReplacePattern (" $", line, "\\\\s");
+        line = RegExHelper.stringReplacePattern ("\t$", line, "\\\\t");
+      }
+      f.print (indent).print (line);
+      firstLine = false;
+      lastEmpty = line.isEmpty ();
+    }
+    f.print (LIMITER);
+    if (!lastEmpty && indentSize > 0)
+    {
+      // if the last line is not empty, then the delimiter is not enough to enforce
+      // the indent. So we add a call after that.
+      f.print (".indent(").print (Integer.toString (indentSize)).print (")");
+    }
+  }
+
+  /// We need to escape initial whitespace to preserve indentation iff
+  /// 1. we are keepWhitespaces
+  /// 2. there are lines
+  /// 3. all non-blank line start with space/tab
+  /// 4. final line starts with space/tab even if blank
+  static boolean requiresEscapeFirstChar (final boolean keepWhitespaces, final @NonNull List <String> lines)
+  {
+    if (!keepWhitespaces)
+      return false;
+
+    if (lines.isEmpty ())
+      return false;
+
+    // no non-blank line that does not start with a space or tab
+    if (lines.stream ()
+             .filter (l -> !(l.isBlank () || l.startsWith (" ") || l.startsWith ("\t")))
+             .findAny ()
+             .isPresent ())
+      return false;
+
+    // if last line does not start with space/tab we don't need to escape, blank or
+    // not.
+    return RegExHelper.stringMatchesPattern ("^[ \\t]+.*", lines.get (lines.size () - 1));
+  }
+
+}

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/writer/JCMWriter.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/writer/JCMWriter.java
@@ -94,10 +94,10 @@ public class JCMWriter
   private String m_sIndentString = DEFAULT_INDENT_STRING;
 
 
-  /// java release our target class files will be compiled under.
+  /// java feature our target class files will be compiled under.
   ///
-  /// For example, a feature requiring java25 will need to be replaced by another code if the release is below 25
-  private int m_iJavaRelease = DEFAULT_JAVA_FEATURE;
+  /// For example, a feature requiring java25 will need to be replaced by another code if the java.feature is below 25
+  private int m_iJavaFeature = DEFAULT_JAVA_FEATURE;
 
   public JCMWriter (@NonNull final JCodeModel aCM)
   {
@@ -172,7 +172,7 @@ public class JCMWriter
    */
   @NonNull
   public int getJavaFeature() {
-    return m_iJavaRelease;
+    return m_iJavaFeature;
   }
 
   /**
@@ -186,7 +186,7 @@ public class JCMWriter
    */
   @NonNull
   public JCMWriter setJavaFeature(final int iJavaFeature) {
-    m_iJavaRelease = iJavaFeature;
+    m_iJavaFeature = iJavaFeature;
     return this;
   }
 

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/writer/JCMWriter.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/writer/JCMWriter.java
@@ -77,6 +77,8 @@ public class JCMWriter
 
   /** Cached default new line */
   public static final String DEFAULT_NEW_LINE = System.lineSeparator ();
+  
+  public static final int DEFAULT_JAVA_FEATURE=17;
 
   private final JCodeModel m_aCM;
 
@@ -90,6 +92,12 @@ public class JCMWriter
    * String to be used for each indentation. Defaults to four spaces.
    */
   private String m_sIndentString = DEFAULT_INDENT_STRING;
+
+
+  /// java release our target class files will be compiled under.
+  ///
+  /// For example, a feature requiring java25 will need to be replaced by another code if the release is below 25
+  private int m_iJavaRelease = DEFAULT_JAVA_FEATURE;
 
   public JCMWriter (@NonNull final JCodeModel aCM)
   {
@@ -160,6 +168,29 @@ public class JCMWriter
   }
 
   /**
+   * @return The javaFeature to be used
+   */
+  @NonNull
+  public int getJavaFeature() {
+    return m_iJavaRelease;
+  }
+
+  /**
+   * Set the javaFeature to be used.
+   *
+   * @param iJavaFeature
+   *                     The java feature to be used. All features that require a
+   *                     higher feature level will be disabled when writting a
+   *                     JCM.
+   * @return this for chaining
+   */
+  @NonNull
+  public JCMWriter setJavaFeature(final int iJavaFeature) {
+    m_iJavaRelease = iJavaFeature;
+    return this;
+  }
+
+  /**
    * Generates Java source code. A convenience method for
    * <code>build(destDir,destDir,status)</code>.
    *
@@ -168,7 +199,7 @@ public class JCMWriter
    * @param aStatusPT
    *        if non-<code>null</code>, progress indication will be sent to this stream.
    * @throws IOException
-   *         on IO error
+   *                     on IO error
    */
   public void build (@NonNull final File aDestDir, @Nullable final IProgressTracker aStatusPT) throws IOException
   {
@@ -270,7 +301,7 @@ public class JCMWriter
       final List <JResourceDir> aResourceDirs = m_aCM.getAllResourceDirs ();
       for (final JResourceDir aResourceDir : aResourceDirs)
         buildResourceDir (aResourceWriter, aResourceDir);
-    }
+      }
     finally
     {
       aSourceWriter.close ();

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/writer/JFormatter.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/writer/JFormatter.java
@@ -400,6 +400,8 @@ public class JFormatter implements IJFormatter
   private boolean m_bContainsErrorTypes;
 
   private boolean m_bDebugImport = false;
+  
+  private int m_iJavaFeature = JCMWriter.DEFAULT_JAVA_FEATURE;
 
   /**
    * Constructor
@@ -418,6 +420,17 @@ public class JFormatter implements IJFormatter
 
     m_aPW = aPW;
     m_sIndentString = sIndentString;
+  }
+  
+  public JFormatter setJavaFeature(int iJavaFeature)
+  {
+    this.m_iJavaFeature=iJavaFeature;
+    return this;
+  }
+  
+  public int getJavaFeature()
+  {
+    return this.m_iJavaFeature;
   }
 
   /**

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JAnnotationUseTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JAnnotationUseTest.java
@@ -40,12 +40,13 @@
  */
 package com.helger.jcodemodel;
 
+import static org.junit.Assert.assertEquals;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.helger.jcodemodel.exceptions.JCodeModelException;
@@ -67,8 +68,7 @@ public final class JAnnotationUseTest
     final JAnnotationUse suppressWarningAnnotation = testClass.annotate (SuppressWarnings.class);
     suppressWarningAnnotation.param (JAnnotationUse.SPECIAL_KEY_VALUE, "unused");
 
-    Assert.assertEquals ("@java.lang.SuppressWarnings(\"unused\")",
-                         CodeModelTestsHelper.generate (suppressWarningAnnotation));
+    assertEquals ("@java.lang.SuppressWarnings(\"unused\")", CodeModelTestsHelper.generate (suppressWarningAnnotation));
   }
 
   @Test
@@ -80,14 +80,14 @@ public final class JAnnotationUseTest
     suppressWarningAnnotation.paramArray (JAnnotationUse.SPECIAL_KEY_VALUE, "unused", "deprecation");
 
     final String sCRLF = JCMWriter.DEFAULT_NEW_LINE;
-    Assert.assertEquals ("@java.lang.SuppressWarnings({" +
-                         sCRLF +
-                         "    \"unused\"," +
-                         sCRLF +
-                         "    \"deprecation\"" +
-                         sCRLF +
-                         "})",
-                         CodeModelTestsHelper.generate (suppressWarningAnnotation));
+    assertEquals ("@java.lang.SuppressWarnings({" +
+                  sCRLF +
+                  "    \"unused\"," +
+                  sCRLF +
+                  "    \"deprecation\"" +
+                  sCRLF +
+                  "})",
+                  CodeModelTestsHelper.generate (suppressWarningAnnotation));
   }
 
   @Test

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JMethodTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JMethodTest.java
@@ -40,7 +40,9 @@
  */
 package com.helger.jcodemodel;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
 import org.junit.Test;
 
 import com.helger.jcodemodel.util.CodeModelTestsHelper;
@@ -61,8 +63,8 @@ public final class JMethodTest
     final JVar foo = m.param (String.class, "foo");
     m.body ().assign (foo, JExpr.lit ("bar"));
 
-    Assert.assertEquals (1, m.params ().size ());
-    Assert.assertSame (foo, m.params ().get (0));
+    assertEquals (1, m.params ().size ());
+    assertSame (foo, m.params ().get (0));
 
     CodeModelTestsHelper.parseCodeModel (cm);
     CodeModelTestsHelper.compileCodeModel (cm);

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JModsTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JModsTest.java
@@ -40,17 +40,18 @@
  */
 package com.helger.jcodemodel;
 
+import static org.junit.Assert.assertEquals;
+
 import java.lang.reflect.Modifier;
 
-import org.junit.Assert;
 import org.junit.Test;
 
-public class JModsTest {
-
+public class JModsTest
+{
   @Test
-  public void testConvertModifiers() {
-    Assert.assertEquals(JMod.PRIVATE, JMods.fromModifier(Modifier.PRIVATE));
-    Assert.assertEquals(Modifier.PROTECTED, JMods.toModifier(JMod.PROTECTED));
+  public void testConvertModifiers ()
+  {
+    assertEquals (JMod.PRIVATE, JMods.fromModifier (Modifier.PRIVATE));
+    assertEquals (Modifier.PROTECTED, JMods.toModifier (JMod.PROTECTED));
   }
-
 }

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JTextBlockTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JTextBlockTest.java
@@ -1,0 +1,37 @@
+package com.helger.jcodemodel;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class JTextBlockTest
+{
+
+  @Test
+  public void testFormatLine ()
+  {
+    // 6 parenthesis should have the 3rd and 6th one escaped
+    assertEquals ("\"\"\\\"\"\"\\\"", JTextBlock.formatLine ("\"".repeat (6)));
+    assertEquals ("\"\"\\\"?\"\"\\\"", JTextBlock.formatLine ("\"".repeat (3) + "?" + "\"".repeat (3)));
+  }
+
+  @Test
+  public void testEscapeLastIfDoubleQuote ()
+  {
+    assertEquals ("", JTextBlock.escapeLastIfDoubleQuote (""));
+    assertEquals ("\\\"", JTextBlock.escapeLastIfDoubleQuote ("\""));
+    assertEquals ("\"\\\"", JTextBlock.escapeLastIfDoubleQuote ("\"\""));
+  }
+
+  @Test
+  public void testConstruction ()
+  {
+    final JTextBlock test = new JTextBlock ();
+    test.add ("a\n b ");
+    assertTrue (test.lines ().filter (l -> l.equals ("a")).findAny ().isPresent ());
+    assertTrue (test.lines ().filter (l -> l.equals (" b ")).findAny ().isPresent ());
+    assertEquals (2L, test.lines ().count ());
+  }
+
+}

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/util/JCNameUtilitiesTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/util/JCNameUtilitiesTest.java
@@ -40,9 +40,9 @@
  */
 package com.helger.jcodemodel.util;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -67,7 +67,7 @@ public final class JCNameUtilitiesTest
                             Inner.class.getSimpleName ();
 
     final String name = JCNameUtilities.getFullName (Inner.class);
-    Assert.assertEquals (expected, name);
+    assertEquals (expected, name);
   }
 
   @Test
@@ -82,7 +82,7 @@ public final class JCNameUtilitiesTest
                             Inner.Inner2.class.getSimpleName ();
 
     final String name = JCNameUtilities.getFullName (Inner.Inner2.class);
-    Assert.assertEquals (expected, name);
+    assertEquals (expected, name);
   }
 
   @Test
@@ -94,6 +94,6 @@ public final class JCNameUtilitiesTest
     final String expected = "MockClassInDefaultPackage";
 
     final String name = JCNameUtilities.getFullName (aClass);
-    Assert.assertEquals (expected, name);
+    assertEquals (expected, name);
   }
 }

--- a/jcodemodeltests/pom.xml
+++ b/jcodemodeltests/pom.xml
@@ -1,20 +1,7 @@
-<!--
-
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-            http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<!-- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and
+limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.helger.jcodemodel</groupId>
@@ -46,7 +33,7 @@
         <version>3.6.1</version>
         <executions>
           <execution>
-            <id>add-test-source</id>
+            <id>add-javatest-generated-source</id>
             <phase>generate-test-sources</phase>
             <goals>
               <goal>add-test-source</goal>
@@ -73,6 +60,12 @@
             <configuration>
               <arguments>${project.basedir}</arguments>
               <mainClass>com.helger.jcodemodel.compile.annotation.GenerateTestFiles</mainClass>
+              <systemProperties>
+                <systemProperty>
+                  <key>java.feature</key>
+                  <value>${java.version}</value>
+                </systemProperty>
+              </systemProperties>
             </configuration>
           </execution>
         </executions>

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/basic/Simple1.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/basic/Simple1.java
@@ -14,5 +14,8 @@
  */
 package com.helger.jcodemodel.tests.basic;
 
+import javax.annotation.processing.Generated;
+
+@Generated("test tester")
 public class Simple1 {
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/basic/Simple2.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/basic/Simple2.java
@@ -14,5 +14,8 @@
  */
 package com.helger.jcodemodel.tests.basic;
 
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
 public class Simple2 {
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/basic/Simple3.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/basic/Simple3.java
@@ -14,5 +14,8 @@
  */
 package com.helger.jcodemodel.tests.basic;
 
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
 public class Simple3 {
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/AnnotatedPerson.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/AnnotatedPerson.java
@@ -14,5 +14,8 @@
  */
 package com.helger.jcodemodel.tests.record;
 
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
 public record AnnotatedPerson(@JRecordTestGen.RecordAnnotationExample String name, int age) {
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/ArrayRecord.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/ArrayRecord.java
@@ -14,5 +14,8 @@
  */
 package com.helger.jcodemodel.tests.record;
 
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
 public record ArrayRecord(String[] names, int[][] matrix) {
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/BasicPoint.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/BasicPoint.java
@@ -14,5 +14,8 @@
  */
 package com.helger.jcodemodel.tests.record;
 
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
 public record BasicPoint(int x, int y) {
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/Empty.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/Empty.java
@@ -14,5 +14,8 @@
  */
 package com.helger.jcodemodel.tests.record;
 
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
 public record Empty() {
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/NamedPoint.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/NamedPoint.java
@@ -14,6 +14,9 @@
  */
 package com.helger.jcodemodel.tests.record;
 
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
 public record NamedPoint(int x, int y, String name)
     implements Comparable<NamedPoint>
 {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/Outer.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/Outer.java
@@ -14,6 +14,9 @@
  */
 package com.helger.jcodemodel.tests.record;
 
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
 public class Outer {
 
     public record Inner(String value) {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/Pair.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/Pair.java
@@ -14,5 +14,8 @@
  */
 package com.helger.jcodemodel.tests.record;
 
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
 public record Pair<T, U>(T first, U second) {
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/PairNumber.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/PairNumber.java
@@ -14,5 +14,8 @@
  */
 package com.helger.jcodemodel.tests.record;
 
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
 public record PairNumber<T extends Number>(T first, T second) {
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/Person.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/Person.java
@@ -14,5 +14,8 @@
  */
 package com.helger.jcodemodel.tests.record;
 
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
 public record Person(String name, Integer age) {
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/PointDistance.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/PointDistance.java
@@ -14,6 +14,9 @@
  */
 package com.helger.jcodemodel.tests.record;
 
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
 public record PointDistance(int x, int y) {
 
     public double distance() {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/PointStatic.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/PointStatic.java
@@ -14,6 +14,9 @@
  */
 package com.helger.jcodemodel.tests.record;
 
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
 public record PointStatic(int x, int y) {
     public static final PointStatic ORIGIN = new PointStatic(0, 0);
 

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/Range.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/Range.java
@@ -14,6 +14,9 @@
  */
 package com.helger.jcodemodel.tests.record;
 
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
 public record Range(int lo, int hi) {
 
     public Range {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/RangeCanonical.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/RangeCanonical.java
@@ -14,6 +14,9 @@
  */
 package com.helger.jcodemodel.tests.record;
 
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
 public record RangeCanonical(int lo, int hi) {
 
     public RangeCanonical(int lo, int hi) {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/SeriesVarArgs.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/record/SeriesVarArgs.java
@@ -14,5 +14,8 @@
  */
 package com.helger.jcodemodel.tests.record;
 
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
 public record SeriesVarArgs(String name, int... values) {
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/textblocks/TextBlocksExample.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/textblocks/TextBlocksExample.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.helger.jcodemodel.tests.textblocks;
+
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
+public class TextBlocksExample {
+    public static final String EMPTY = """
+    """;
+    public static final String ONE_LINE = """
+    a""";
+    public static final String TWO_LINES = """
+    a
+    b""";
+    public static final String TWO_DOUBLE_DQUOTES_LINES = """
+    ""
+    "\"""";
+    public static final String TWO_TRIPLE_DQUOTES_LINES = """
+    ""\"
+    ""\"""";
+    public static final String FIVE_DQUOTES = """
+    ""\""\"""";
+    public static final String TWO_FIVE_DQUOTES_LINES = """
+    ""\"""
+    ""\""\"""";
+    public static final String ONE_LINE_ENDSPACE = """
+    a  """;
+    public static final String ONE_LINE_ENDTAB = """
+    a		""";
+    public static final String TWO_LINES_ENDTAB = """
+    a		
+    b		""";
+}

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/textblocks/TextBlocksKeepWhiteSpaces.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/textblocks/TextBlocksKeepWhiteSpaces.java
@@ -12,19 +12,29 @@
  * limitations under the License.
  * 
  */
-package com.helger.jcodemodel.tests.record;
+package com.helger.jcodemodel.tests.textblocks;
 
 import javax.annotation.processing.Generated;
 
-
-/**
- * Represents a 2D point.
- * 
- * @param x
- *     the x coordinate
- * @param y
- *     the y coordinate
- */
 @Generated("com.helger.jcodemodel.JCodeModel")
-public record PointJavadoc(int x, int y) {
+public class TextBlocksKeepWhiteSpaces {
+    public static final String ONE_LINE_SPACES = """
+    \s a \s""";
+    public static final String ONE_LINE_TABS = """
+    \ta\t""";
+    public static final String SPACES_EMPTYLINE = """
+     \s
+    """;
+    public static final String THREE_LINES_SPACES = """
+    \sa\s
+     b\s
+     c \s""";
+    public static final String EMPTY_THEN_SPACED = """
+
+    \s a""";
+    public static final String TWO_EMPTY_LINES_2SPACES_3SPACES = """
+
+
+    \s\s
+      \s""";
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/unnamed/SimpleUnnamed.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/unnamed/SimpleUnnamed.java
@@ -14,6 +14,9 @@
  */
 package com.helger.jcodemodel.tests.unnamed;
 
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
 public class SimpleUnnamed {
 
     public boolean equals(Object _unnamed) {

--- a/jcodemodeltests/src/main/java/com/helger/jcodemodel/compile/annotation/GenerateTestFiles.java
+++ b/jcodemodeltests/src/main/java/com/helger/jcodemodel/compile/annotation/GenerateTestFiles.java
@@ -24,34 +24,34 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
+import javax.annotation.processing.Generated;
+
 import com.helger.jcodemodel.JCodeModel;
 import com.helger.jcodemodel.JPackage;
+import com.helger.jcodemodel.JReferencedClass;
 import com.helger.jcodemodel.writer.JCMWriter;
 import com.helger.jcodemodel.writer.ProgressCodeWriter.IProgressTracker;
 
-public class GenerateTestFiles {
-
+public class GenerateTestFiles
+{
   private static final String OUTPUT_DIR = "src/generated/javatest";
-
   private static final String CLASS_SCAN_DIR = "src/main/java";
-
   private static final String LICENCE = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+              http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-""";
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+      """;
 
-  private final File outputDir;
-
-  private final File classScanDir;
+  private final File m_aOutputDir;
+  private final File m_aClassScanDir;
 
   private final int javaFeature;
 
@@ -68,145 +68,199 @@ limitations under the License.
   }
 
   public GenerateTestFiles(File outputDir, File classScanDir) {
-    this.outputDir = outputDir;
-    this.classScanDir = classScanDir;
+    m_aOutputDir = outputDir;
+    m_aClassScanDir = classScanDir;
     javaFeature = extractJavaFeature();
-  }
-
-  void apply() {
-    delete(outputDir);
-    outputDir.mkdirs();
-    scanClasses(classScanDir).forEach(this::applyCandidateClass);
 
   }
 
-  void delete(File file) {
-    if (file.isDirectory()) {
-      for (File sub : file.listFiles()) {
-        delete(sub);
+  void apply ()
+  {
+    delete (m_aOutputDir);
+    m_aOutputDir.mkdirs ();
+    scanClasses (m_aClassScanDir).forEach (this::applyCandidateClass);
+  }
+
+  void delete (final File file)
+  {
+    if (file.isDirectory ())
+    {
+      for (final File sub : file.listFiles ())
+      {
+        delete (sub);
       }
     }
-    file.delete();
+    file.delete ();
   }
 
-  Stream<String> scanClasses(File rootDir) {
-    return scanClasses(rootDir, "", Stream.of());
+  Stream <String> scanClasses (final File rootDir)
+  {
+    return scanClasses (rootDir, "", Stream.of ());
   }
 
-  Stream<String> scanClasses(File dir, String packageName, Stream<String> stream) {
-    List<String> newFound = new ArrayList<>();
-    if (!dir.isDirectory()) {
-      throw new RuntimeException("file " + dir.getAbsolutePath() + " expected to be a dir");
+  Stream <String> scanClasses (final File dir, final String packageName, final Stream <String> stream)
+  {
+    Stream <String> ret = stream;
+    final List <String> newFound = new ArrayList <> ();
+    if (!dir.isDirectory ())
+    {
+      throw new RuntimeException ("file " + dir.getAbsolutePath () + " expected to be a dir");
     }
-    for (File child : dir.listFiles()) {
-      if (child.isDirectory()) {
-        stream = scanClasses(child, (packageName.isEmpty() ? "" : packageName + ".") + child.getName(), stream);
+    for (final File child : dir.listFiles ())
+    {
+      if (child.isDirectory ())
+      {
+        ret = scanClasses (child, (packageName.isEmpty () ? "" : packageName + ".") + child.getName (), ret);
 
-      } else if (child.isFile() && child.getName().endsWith(".java")) {
-        newFound.add(packageName + "." + child.getName().replace(".java", ""));
+      }
+      else
+        if (child.isFile () && child.getName ().endsWith (".java"))
+        {
+          newFound.add (packageName + "." + child.getName ().replace (".java", ""));
+        }
+    }
+    if (!newFound.isEmpty ())
+    {
+      ret = Stream.concat (ret, newFound.stream ());
+    }
+    return ret;
+  }
+
+  void applyCandidateClass (final String className)
+  {
+    Class <?> clazz;
+    try
+    {
+      clazz = Class.forName (className);
+      if (clazz.getAnnotation (TestJCM.class) != null)
+      {
+        runGeneration (clazz);
       }
     }
-    if (!newFound.isEmpty()) {
-      stream = Stream.concat(stream, newFound.stream());
-    }
-    return stream;
-  }
-
-  void applyCandidateClass(String className) {
-    Class<?> clazz;
-    try {
-      clazz = Class.forName(className);
-      if (clazz.getAnnotation(TestJCM.class) != null) {
-        runGeneration(clazz);
-      }
-    } catch (ClassNotFoundException
-        | IllegalAccessException
-        | IllegalArgumentException
-        | InvocationTargetException
-        | InstantiationException
-        | NoSuchMethodException
-        | SecurityException
-        | IOException e) {
-      throw new RuntimeException(e);
+    catch (ClassNotFoundException | IllegalAccessException | IllegalArgumentException | InvocationTargetException |
+           InstantiationException | NoSuchMethodException | SecurityException | IOException e)
+    {
+      throw new RuntimeException (e);
     }
   }
 
-  private void runGeneration(Class<?> clazz)
-      throws IllegalAccessException,
-      IllegalArgumentException,
-      InvocationTargetException,
-      InstantiationException,
-      NoSuchMethodException,
-      SecurityException,
-      IOException {
-    for (Method m : clazz.getDeclaredMethods()) {
+  private void runGeneration (final Class <?> clazz) throws IllegalAccessException,
+                                                     IllegalArgumentException,
+                                                     InvocationTargetException,
+                                                     InstantiationException,
+                                                     NoSuchMethodException,
+                                                     SecurityException,
+                                                     IOException
+  {
+    for (final Method m : clazz.getDeclaredMethods ())
+    {
       // only apply to methods public
       // and that produce a JCodeModel or require one or a package
-      if ((m.getModifiers() & Modifier.PUBLIC) > 0) {
-        boolean returnsJCM = m.getReturnType().equals(JCodeModel.class);
+      if ((m.getModifiers () & Modifier.PUBLIC) > 0)
+      {
+        final boolean returnsJCM = m.getReturnType ().equals (JCodeModel.class);
         boolean requiresJCM = false;
-        Object[] params = new Object[m.getParameterCount()];
+        final Object [] params = new Object [m.getParameterCount ()];
         boolean unknownParam = false;
         JCodeModel produced = null;
         JPackage rootPackage = null;
-        for (int i = 0; i < params.length; i++) {
-          Parameter param = m.getParameters()[i];
-          if (param.getType() == JCodeModel.class) {
-            if (produced == null) {
-              produced = new JCodeModel();
+        for (int i = 0; i < params.length; i++)
+        {
+          final Parameter param = m.getParameters ()[i];
+          if (param.getType () == JCodeModel.class)
+          {
+            if (produced == null)
+            {
+              produced = new JCodeModel ();
             }
             params[i] = produced;
             requiresJCM = true;
-          } else if (param.getType() == JPackage.class) {
-            // request a root package that is the package of the class
-            if (produced == null) {
-              produced = new JCodeModel();
-            }
-            if (rootPackage == null) {
-              rootPackage = produced._package(clazz.getPackageName());
-            }
-            params[i] = rootPackage;
-            requiresJCM = true;
+          }
+          else
+            if (param.getType () == JPackage.class)
+            {
+              // request a root package that is the package of the class
+              if (produced == null)
+              {
+                produced = new JCodeModel ();
+              }
+              if (rootPackage == null)
+              {
+                rootPackage = produced._package (clazz.getPackageName ());
+              }
+              params[i] = rootPackage;
+              requiresJCM = true;
 
-          } else {
-            unknownParam = true;
-          }
+            }
+            else
+            {
+              unknownParam = true;
+            }
         }
-        if (!unknownParam && (returnsJCM || requiresJCM)) {
-          m.setAccessible(true);
-          if ((m.getModifiers() & Modifier.STATIC) > 0) {
-            if (returnsJCM) {
-              produced = (JCodeModel) m.invoke(null, params);
-            } else {
-              m.invoke(null, params);
+        if (!unknownParam && (returnsJCM || requiresJCM))
+        {
+          m.setAccessible (true);
+          if ((m.getModifiers () & Modifier.STATIC) > 0)
+          {
+            if (returnsJCM)
+            {
+              produced = (JCodeModel) m.invoke (null, params);
             }
-          } else {
-            Object inst = clazz.getDeclaredConstructor().newInstance();
-            if (returnsJCM) {
-              produced = (JCodeModel) m.invoke(inst, params);
-            } else {
-              m.invoke(inst, params);
+            else
+            {
+              m.invoke (null, params);
             }
           }
-          if (produced != null) {
-            postProcessJCM(produced);
-            new JCMWriter(produced)
-                .setJavaFeature(javaFeature)
-                .build(outputDir, (IProgressTracker) null);
+
+          else
+          {
+            final Object inst = clazz.getDeclaredConstructor ().newInstance ();
+            if (returnsJCM)
+            {
+              produced = (JCodeModel) m.invoke (inst, params);
+            }
+            else
+            {
+              m.invoke (inst, params);
+            }
+          }
+          if (produced != null)
+          {
+            postProcessJCM (produced);
+            new JCMWriter (produced).build (m_aOutputDir, (IProgressTracker) null);
           }
         }
       }
     }
   }
 
-  protected void postProcessJCM(JCodeModel jcm) {
-    jcm.getAllPackages().stream()
-        .flatMap(jp -> jp.classes().stream())
-        .filter(jdc -> !jdc.isHidden())
-        .filter(jdc -> !jdc.hasHeaderComment())
-        .forEach(jdc -> {
-          jdc.headerComment().add(LICENCE);
-        });
+  protected void postProcessJCM (final JCodeModel jcm)
+  {
+    // add the licence to classes not having a header comment yet.
+    jcm.getAllPackages ()
+       .stream ()
+       .flatMap (jp -> jp.classes ().stream ())
+       .filter (jdc -> !jdc.isHidden ())
+       .filter (jdc -> !jdc.hasHeaderComment ())
+       .forEach (jdc -> {
+         jdc.headerComment ().add (LICENCE);
+       });
+
+    // add @Generated(JCodeModel full name) to files' root classes not having that annotation yet.
+    jcm.getAllPackages ()
+       .stream ()
+       .flatMap (jp -> jp.classes ().stream ())
+       .filter (jdc -> !jdc.isHidden ())
+       .filter (jdc -> jdc.annotations ()
+                          .stream ()
+                          .filter (ja -> ja.getAnnotationClass () instanceof JReferencedClass)
+                          .map (ja -> (JReferencedClass) ja.getAnnotationClass ())
+                          .filter (jrc -> jrc.getReferencedClass ().equals (Generated.class))
+                          .findAny ()
+                          .isEmpty ())
+       .forEach (jdc -> {
+         jdc.annotate (Generated.class).param (JCodeModel.class.getCanonicalName ());
+       });
   }
 
 }

--- a/jcodemodeltests/src/main/java/com/helger/jcodemodel/compile/annotation/GenerateTestFiles.java
+++ b/jcodemodeltests/src/main/java/com/helger/jcodemodel/compile/annotation/GenerateTestFiles.java
@@ -53,6 +53,8 @@ limitations under the License.
 
   private final File classScanDir;
 
+  private final int javaFeature;
+
   public static void main(String[] args) {
     String rootPath = args == null || args.length == 0 ? "." : args[0];
     File outputFile = new File(rootPath, OUTPUT_DIR);
@@ -61,9 +63,14 @@ limitations under the License.
         .apply();
   }
 
+  public static int extractJavaFeature() {
+    return Integer.parseInt(System.getProperty("java.feature", "" + JCMWriter.DEFAULT_JAVA_FEATURE));
+  }
+
   public GenerateTestFiles(File outputDir, File classScanDir) {
     this.outputDir = outputDir;
     this.classScanDir = classScanDir;
+    javaFeature = extractJavaFeature();
   }
 
   void apply() {
@@ -183,7 +190,9 @@ limitations under the License.
           }
           if (produced != null) {
             postProcessJCM(produced);
-            new JCMWriter(produced).build(outputDir, (IProgressTracker) null);
+            new JCMWriter(produced)
+                .setJavaFeature(javaFeature)
+                .build(outputDir, (IProgressTracker) null);
           }
         }
       }

--- a/jcodemodeltests/src/main/java/com/helger/jcodemodel/compile/annotation/GenerateTestFiles.java
+++ b/jcodemodeltests/src/main/java/com/helger/jcodemodel/compile/annotation/GenerateTestFiles.java
@@ -139,7 +139,7 @@ limitations under the License.
         boolean returnsJCM = m.getReturnType().equals(JCodeModel.class);
         boolean requiresJCM = false;
         Object[] params = new Object[m.getParameterCount()];
-        boolean missingParam = false;
+        boolean unknownParam = false;
         JCodeModel produced = null;
         JPackage rootPackage = null;
         for (int i = 0; i < params.length; i++) {
@@ -162,10 +162,10 @@ limitations under the License.
             requiresJCM = true;
 
           } else {
-            missingParam = true;
+            unknownParam = true;
           }
         }
-        if (!missingParam && (returnsJCM || requiresJCM)) {
+        if (!unknownParam && (returnsJCM || requiresJCM)) {
           m.setAccessible(true);
           if ((m.getModifiers() & Modifier.STATIC) > 0) {
             if (returnsJCM) {

--- a/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/basic/SimpleClassGenerating.java
+++ b/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/basic/SimpleClassGenerating.java
@@ -14,39 +14,45 @@
  */
 package com.helger.jcodemodel.tests.basic;
 
+import javax.annotation.processing.Generated;
+
 import com.helger.jcodemodel.JPackage;
 import com.helger.jcodemodel.compile.annotation.TestJCM;
 import com.helger.jcodemodel.exceptions.JCodeModelException;
 
 @TestJCM
-public class SimpleClassGenerating {
-
-  public void createSimple1(JPackage root) throws JCodeModelException {
-    root._class("Simple1");
+public class SimpleClassGenerating
+{
+  public void createSimple1 (final JPackage root) throws JCodeModelException
+  {
+    root._class ("Simple1").annotate (Generated.class).param ("test tester");
   }
 
-
-  public void createSimple2(JPackage root, JPackage root2) throws JCodeModelException {
+  public void createSimple2 (final JPackage root, final JPackage root2) throws JCodeModelException
+  {
     assert root == root2;
-    root._class("Simple2");
+    root._class ("Simple2");
   }
 
-  /**
+  /*
    * protected so should not be selected
    */
-  protected void protectedCall(JPackage root) throws JCodeModelException {
-    root._class("ERROR");
+  protected void protectedCall (final JPackage root) throws JCodeModelException
+  {
+    root._class ("ERROR");
   }
 
-  /**
+  /*
    * requires a param too many so should not be selected
    */
-  public void invalidParamCall(JPackage root, Object o) throws JCodeModelException {
-    root._class("ERROR2");
+  public void invalidParamCall (final JPackage root, @SuppressWarnings ("unused") final Object o)
+                                                                                                  throws JCodeModelException
+  {
+    root._class ("ERROR2");
   }
 
-  public static void staticSimple(JPackage root) throws JCodeModelException {
-    root._class("Simple3");
+  public static void staticSimple (final JPackage root) throws JCodeModelException
+  {
+    root._class ("Simple3");
   }
-
 }

--- a/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTestGen.java
+++ b/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTestGen.java
@@ -1,0 +1,80 @@
+package com.helger.jcodemodel.tests.textblocks;
+
+import com.helger.jcodemodel.JDefinedClass;
+import com.helger.jcodemodel.JExpr;
+import com.helger.jcodemodel.JMod;
+import com.helger.jcodemodel.JPackage;
+import com.helger.jcodemodel.compile.annotation.TestJCM;
+import com.helger.jcodemodel.exceptions.JCodeModelException;
+
+@TestJCM
+public class TextBlocksTestGen
+{
+
+  public void basicExamples (final JPackage root) throws JCodeModelException
+  {
+    final JDefinedClass cl = root._class ("TextBlocksExample");
+    cl.field (JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "EMPTY", JExpr.textBlock ());
+    cl.field (JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "ONE_LINE", JExpr.textBlock ().add ("a"));
+    cl.field (JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "TWO_LINES", JExpr.textBlock ().add ("a\nb"));
+
+    cl.field (JMod.PUBLIC | JMod.STATIC | JMod.FINAL,
+              String.class,
+              "TWO_DOUBLE_DQUOTES_LINES",
+              JExpr.textBlock ().add ("\"\"\n\"\""));
+    cl.field (JMod.PUBLIC | JMod.STATIC | JMod.FINAL,
+              String.class,
+              "TWO_TRIPLE_DQUOTES_LINES",
+              JExpr.textBlock ().add ("\"\"\"\n\"\"\""));
+    cl.field (JMod.PUBLIC | JMod.STATIC | JMod.FINAL,
+              String.class,
+              "FIVE_DQUOTES",
+              JExpr.textBlock ().add ("\"".repeat (5)));
+    cl.field (JMod.PUBLIC | JMod.STATIC | JMod.FINAL,
+              String.class,
+              "TWO_FIVE_DQUOTES_LINES",
+              JExpr.textBlock ().add ("\"".repeat (5)).add ("\"".repeat (5)));
+
+    cl.field (JMod.PUBLIC | JMod.STATIC | JMod.FINAL,
+              String.class,
+              "ONE_LINE_ENDSPACE",
+              JExpr.textBlock ().add ("a  "));
+    cl.field (JMod.PUBLIC | JMod.STATIC | JMod.FINAL,
+              String.class,
+              "ONE_LINE_ENDTAB",
+              JExpr.textBlock ().add ("a\t\t"));
+    cl.field (JMod.PUBLIC | JMod.STATIC | JMod.FINAL,
+              String.class,
+              "TWO_LINES_ENDTAB",
+              JExpr.textBlock ().add ("a\t\t").add ("b\t\t"));
+  }
+
+  public void keepWhiteSpaces (final JPackage root) throws JCodeModelException
+  {
+    final JDefinedClass cl = root._class ("TextBlocksKeepWhiteSpaces");
+    cl.field (JMod.PUBLIC | JMod.STATIC | JMod.FINAL,
+              String.class,
+              "ONE_LINE_SPACES",
+              JExpr.textBlock ().keepWhitespaces (true).add ("  a  "));
+    cl.field (JMod.PUBLIC | JMod.STATIC | JMod.FINAL,
+              String.class,
+              "ONE_LINE_TABS",
+              JExpr.textBlock ().keepWhitespaces (true).add ("	a	"));
+    cl.field (JMod.PUBLIC | JMod.STATIC | JMod.FINAL,
+              String.class,
+              "SPACES_EMPTYLINE",
+              JExpr.textBlock ().keepWhitespaces (true).add ("  ").newline ());
+    cl.field (JMod.PUBLIC | JMod.STATIC | JMod.FINAL,
+              String.class,
+              "THREE_LINES_SPACES",
+              JExpr.textBlock ().keepWhitespaces (true).add (" a ").add (" b ").add (" c  "));
+    cl.field (JMod.PUBLIC | JMod.STATIC | JMod.FINAL,
+              String.class,
+              "EMPTY_THEN_SPACED",
+              JExpr.textBlock ().keepWhitespaces (true).newline ().add ("  a"));
+    cl.field (JMod.PUBLIC | JMod.STATIC | JMod.FINAL,
+              String.class,
+              "TWO_EMPTY_LINES_2SPACES_3SPACES",
+              JExpr.textBlock ().keepWhitespaces (true).newline ().newline ().add ("  ").add ("   "));
+  }
+}

--- a/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/record/JRecordTest.java
+++ b/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/record/JRecordTest.java
@@ -30,117 +30,118 @@ import com.helger.jcodemodel.tests.record.Outer.Inner;
  * canonical constructor - Private final fields for each component - Public accessor methods for
  * each component (same name as component) - equals(), hashCode(), and toString() implementations
  */
+@SuppressWarnings ("cast")
 public final class JRecordTest
 {
-
   /**
    * tests {@link JRecordTestGen#testBasicRecord()}
    */
   @Test
-  public void testBasicRecord()
+  public void testBasicRecord ()
   {
-    BasicPoint test = new BasicPoint(2, 3);
-    Assert.assertTrue(test instanceof Record);
-    Assert.assertEquals(2, test.x());
-    Assert.assertEquals(3, test.y());
+    final BasicPoint test = new BasicPoint (2, 3);
+    Assert.assertTrue (test instanceof Record);
+    Assert.assertEquals (2, test.x ());
+    Assert.assertEquals (3, test.y ());
   }
 
   /**
    * tests {@link JRecordTestGen#testEmptyRecord()}
    */
   @Test
-  public void testEmptyRecord()
+  public void testEmptyRecord ()
   {
-    Empty test = new Empty();
-    Assert.assertTrue(test instanceof Record);
+    final Empty test = new Empty ();
+    Assert.assertTrue (test instanceof Record);
   }
 
   /**
    * tests {@link JRecordTestGen#testRecordWithObjectComponents()}
    */
   @Test
-  public void testRecordWithObjectComponents()
+  public void testRecordWithObjectComponents ()
   {
-    Person test = new Person("John", 42);
-    Assert.assertTrue(test instanceof Record);
-    Assert.assertEquals((Integer) 42, test.age());
-    Assert.assertEquals("John", test.name());
+    final Person test = new Person ("John", Integer.valueOf (42));
+    Assert.assertTrue (test instanceof Record);
+    Assert.assertEquals (Integer.valueOf (42), test.age ());
+    Assert.assertEquals ("John", test.name ());
   }
 
   /**
    * tests {@link JRecordTestGen#testRecordImplementsInterface()}
    */
   @Test
-  public void testRecordImplementsInterface()
+  public void testRecordImplementsInterface ()
   {
-    NamedPoint test = new NamedPoint(5, 10, "15");
-    Assert.assertTrue(test instanceof Record);
-    Assert.assertTrue(test instanceof Comparable<NamedPoint>);
-    Assert.assertEquals("15", test.name());
-    Assert.assertEquals(5, test.x());
-    Assert.assertEquals(10, test.y());
+    final NamedPoint test = new NamedPoint (5, 10, "15");
+    Assert.assertTrue (test instanceof Record);
+    Assert.assertTrue (test instanceof Comparable <NamedPoint>);
+    Assert.assertEquals ("15", test.name ());
+    Assert.assertEquals (5, test.x ());
+    Assert.assertEquals (10, test.y ());
   }
 
   /**
    * tests {@link JRecordTestGen#testGenericRecord()}
    */
   @Test
-  public void testGenericRecord()
+  public void testGenericRecord ()
   {
-    Pair<Integer, String> test = new Pair<>(666, "BE NOT AFRAID");
-    Assert.assertTrue(test instanceof Record);
-    Assert.assertEquals((Integer) 666, test.first());
-    Assert.assertEquals("BE NOT AFRAID", test.second());
+    final Pair <Integer, String> test = new Pair <> (Integer.valueOf (666), "BE NOT AFRAID");
+    Assert.assertTrue (test instanceof Record);
+    Assert.assertEquals (Integer.valueOf (666), test.first ());
+    Assert.assertEquals ("BE NOT AFRAID", test.second ());
   }
 
   /**
    * tests {@link JRecordTestGen#testRecordWithBoundedTypeParameter()}
    */
   @Test
-  public void testRecordWithBoundedTypeParameter()
+  public void testRecordWithBoundedTypeParameter ()
   {
-    PairNumber<BigDecimal> test = new PairNumber<>(BigDecimal.ONE, BigDecimal.ZERO);
-    Assert.assertTrue(test instanceof Record);
+    final PairNumber <BigDecimal> test = new PairNumber <> (BigDecimal.ONE, BigDecimal.ZERO);
+    Assert.assertTrue (test instanceof Record);
   }
 
   /**
    * tests {@link JRecordTestGen#testRecordWithAnnotatedComponent()}
    *
    * @throws SecurityException
-   * @throws NoSuchFieldException
+   *         in case of error
    */
   @Test
-  public void testRecordWithAnnotatedComponent()
+  public void testRecordWithAnnotatedComponent ()
   {
-    AnnotatedPerson test = new AnnotatedPerson("Salomon", 2000);
-    Assert.assertTrue(test instanceof Record);
+    final AnnotatedPerson test = new AnnotatedPerson ("Salomon", 2000);
+    Assert.assertTrue (test instanceof Record);
 
-    RecordComponent fieldComponent = Stream.of(test.getClass().getRecordComponents())
-        .filter(rc -> rc.getName().equals("name"))
-        .findFirst().get();
-    Assert.assertTrue(fieldComponent.isAnnotationPresent(RecordAnnotationExample.class));
+    final RecordComponent fieldComponent = Stream.of (test.getClass ().getRecordComponents ())
+                                                 .filter (rc -> rc.getName ().equals ("name"))
+                                                 .findFirst ()
+                                                 .get ();
+    Assert.assertTrue (fieldComponent.isAnnotationPresent (RecordAnnotationExample.class));
   }
 
   /**
    * tests {@link JRecordTestGen#testRecordWithCompactConstructor()}
    */
   @Test
-  public void testRecordWithCompactConstructor()
+  public void testRecordWithCompactConstructor ()
   {
-    Range test = new Range(1, 5);
-    Assert.assertTrue(test instanceof Record);
-    Assert.assertThrows(IllegalArgumentException.class, () -> new Range(5, 1));
+    final Range test = new Range (1, 5);
+    Assert.assertTrue (test instanceof Record);
+    Assert.assertThrows (IllegalArgumentException.class, () -> new Range (5, 1));
   }
 
   /**
    * tests {@link JRecordTestGen#testRecordWithCanonicalConstructor()}
    */
   @Test
-  public void testRecordWithCanonicalConstructor()
+  public void testRecordWithCanonicalConstructor ()
   {
-    RangeCanonical test = new RangeCanonical(1, 5);
-    Assert.assertTrue(test instanceof Record);
-    Assert.assertThrows(IllegalArgumentException.class, () -> new RangeCanonical(5, 1));
+    final RangeCanonical test = new RangeCanonical (1, 5);
+    Assert.assertTrue (test instanceof Record);
+    Assert.assertThrows (IllegalArgumentException.class, () -> new RangeCanonical (5, 1));
   }
 
   /**
@@ -149,66 +150,67 @@ public final class JRecordTest
   @Test
   public void testRecordWithMethod ()
   {
-    PointDistance test = new PointDistance(0, 0);
-    Assert.assertTrue(test instanceof Record);
-    Assert.assertEquals(0, test.distance(), 0.0);
+    final PointDistance test = new PointDistance (0, 0);
+    Assert.assertTrue (test instanceof Record);
+    Assert.assertEquals (0, test.distance (), 0.0);
   }
 
   /**
    * tests {@link JRecordTestGen#testRecordWithStaticMembers()}
    */
   @Test
-  public void testRecordWithStaticMembers()
+  public void testRecordWithStaticMembers ()
   {
     PointStatic test = PointStatic.ORIGIN;
-    Assert.assertTrue(test instanceof Record);
-    test = PointStatic.of(6, 78);
-    Assert.assertEquals(6, test.x());
-    Assert.assertEquals(78, test.y());
+    Assert.assertTrue (test instanceof Record);
+    test = PointStatic.of (6, 78);
+    Assert.assertEquals (6, test.x ());
+    Assert.assertEquals (78, test.y ());
   }
 
   /**
    * tests {@link JRecordTestGen#testNestedRecord()}
    */
   @Test
-  public void testNestedRecord()
+  public void testNestedRecord ()
   {
-    Inner test = new Inner("NaN");
-    Assert.assertTrue(test instanceof Record);
-    Assert.assertEquals("NaN", test.value());
+    final Inner test = new Inner ("NaN");
+    Assert.assertTrue (test instanceof Record);
+    Assert.assertEquals ("NaN", test.value ());
   }
 
   /**
    * tests {@link JRecordTestGen#testRecordWithJavadoc()}
    */
   @Test
-  public void testRecordWithJavadoc() {
+  public void testRecordWithJavadoc ()
+  {
     // nothing to do to test javadoc ??
-    PointJavadoc test = new PointJavadoc(0, 0);
-    Assert.assertTrue(test instanceof Record);
+    final PointJavadoc test = new PointJavadoc (0, 0);
+    Assert.assertTrue (test instanceof Record);
   }
 
   /**
    * tests {@link JRecordTestGen#testRecordWithVarargsComponent()}
    */
   @Test
-  public void testRecordWithVarargsComponent()
+  public void testRecordWithVarargsComponent ()
   {
-    SeriesVarArgs test = new SeriesVarArgs("Fibonacci", 1,1,3,4);
-    Assert.assertTrue(test instanceof Record);
-    Assert.assertArrayEquals(test.values(), new int[] { 1, 1, 3, 4 });
+    final SeriesVarArgs test = new SeriesVarArgs ("Fibonacci", 1, 1, 3, 4);
+    Assert.assertTrue (test instanceof Record);
+    Assert.assertArrayEquals (test.values (), new int [] { 1, 1, 3, 4 });
   }
 
   /**
    * tests {@link JRecordTestGen#testRecordWithArrayComponent()}
    */
   @Test
-  public void testRecordWithArrayComponent() {
-    ArrayRecord test = new ArrayRecord(new String[] { "id" }, new int[][] { { 1, 2 } });
-    Assert.assertTrue(test instanceof Record);
-    Assert.assertArrayEquals(test.names(), new String[] { "id" });
-    Assert.assertArrayEquals(test.matrix()[0], new int[] { 1, 2 });
-
+  public void testRecordWithArrayComponent ()
+  {
+    final ArrayRecord test = new ArrayRecord (new String [] { "id" }, new int [] [] { { 1, 2 } });
+    Assert.assertTrue (test instanceof Record);
+    Assert.assertArrayEquals (test.names (), new String [] { "id" });
+    Assert.assertArrayEquals (test.matrix ()[0], new int [] { 1, 2 });
   }
 
 }

--- a/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTest.java
+++ b/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTest.java
@@ -1,0 +1,35 @@
+package com.helger.jcodemodel.tests.textblocks;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class TextBlocksTest
+{
+
+  @Test
+  public void testBasicExamples ()
+  {
+    assertEquals ("", TextBlocksExample.EMPTY);
+    assertEquals ("a", TextBlocksExample.ONE_LINE);
+    assertEquals ("a\nb", TextBlocksExample.TWO_LINES);
+    assertEquals ("\"\"\n\"\"", TextBlocksExample.TWO_DOUBLE_DQUOTES_LINES);
+    assertEquals ("\"\"\"\n\"\"\"", TextBlocksExample.TWO_TRIPLE_DQUOTES_LINES);
+    assertEquals ("\"\"\"\"\"", TextBlocksExample.FIVE_DQUOTES);
+    assertEquals ("\"\"\"\"\"\n\"\"\"\"\"", TextBlocksExample.TWO_FIVE_DQUOTES_LINES);
+    assertEquals ("a", TextBlocksExample.ONE_LINE_ENDSPACE);
+    assertEquals ("a", TextBlocksExample.ONE_LINE_ENDTAB);
+    assertEquals ("a\nb", TextBlocksExample.TWO_LINES_ENDTAB);
+  }
+
+  @Test
+  public void testKeepWhiteSpaces ()
+  {
+    assertEquals ("  a  ", TextBlocksKeepWhiteSpaces.ONE_LINE_SPACES);
+    assertEquals ("	a	", TextBlocksKeepWhiteSpaces.ONE_LINE_TABS);
+    assertEquals ("  \n", TextBlocksKeepWhiteSpaces.SPACES_EMPTYLINE);
+    assertEquals (" a \n b \n c  ", TextBlocksKeepWhiteSpaces.THREE_LINES_SPACES);
+    assertEquals ("\n  a", TextBlocksKeepWhiteSpaces.EMPTY_THEN_SPACED);
+    assertEquals ("\n\n  \n   ", TextBlocksKeepWhiteSpaces.TWO_EMPTY_LINES_2SPACES_3SPACES);
+  }
+}

--- a/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/GenerateSourceMojo.java
+++ b/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/GenerateSourceMojo.java
@@ -67,6 +67,12 @@ public class GenerateSourceMojo extends AbstractMojo
   @Parameter (property = "jcodemodel.source")
   private String source;
 
+  /**
+   * features allowed in the generated class files
+   */
+  @Parameter (property = "jcodemodel.java.feature")
+  private String javaFeature;
+
   @Parameter (property = "jcodemodel.data")
   private String data;
 
@@ -138,7 +144,9 @@ public class GenerateSourceMojo extends AbstractMojo
                                                                                                                         .getBytes (StandardCharsets.UTF_8)))
     {
       cmb.build (cm, aIS);
-      new JCMWriter (cm).build (dir, (IProgressTracker) null);
+      new JCMWriter (cm)
+        .setJavaFeature(findJavaFeature())
+        .build (dir, (IProgressTracker) null);
     }
     catch (JCodeModelException | IOException e)
     {
@@ -219,5 +227,10 @@ public class GenerateSourceMojo extends AbstractMojo
     }
 
     throw new MojoExecutionException ("could not open provided source " + source + " as a file or url");
+  }
+  
+  public int findJavaFeature() {
+    if(javaFeature==null || javaFeature.isBlank()) return JCMWriter.DEFAULT_JAVA_FEATURE;
+    return Integer.parseInt(javaFeature);
   }
 }


### PR DESCRIPTION
# What is java feature

It's the major part of the installed java version, for example 127 for java 127.0.0.1 .

Allowed java features are the same among different versions of a same java feature, and typically kept later.
For example lambdas were added in java 8 . So the lambdas features requires java feature 8+. A code that uses the "lambda" feature will fail to compile by javac <8 ; and the class files generated by javac from this code will fail to run on a jre <8 .

This value  is stored inside the java .class files produced by javac.

# What is Java release

It's the same, but at the scope of a project. The java release, also known as java.version, is set in the maven project to know what version to validate the java source files, as well as what feature to store in the compiled .class files.

The java installation used to build with maven must be at least this feature. If I have jdk 7 I can't build project with release 8.

Any feature from a later java release is disabled and therefore their inclusion in the project will make the build fail.

This is important because in the event we work with a more recent java installation, we still want the java generated class files to be runnable on an older java version. 

# Why it's needed

If we want to incorporate recent features, those need a way to generate replacement code when the target java release is below the required java feature of that feature.

For example, If I want to add switch patterns, then I need java feature 25, but if the java release is  lower, I need to use fallback code instead (so a series of instanceof at the top of the default case).

For this, the JCM code must be aware of that value. This is what this PR provides.

# Changes

1. default java feature added in the JCMWriter so any later change can be set here.
2. added JCMWriter.javaFeature property. 
3. added JFormatter.javaFeature property. This is passed from JCMWriter
4. passing the java.version to the system property java.feature in the jcodemodeltests, using it in the GenerateTestFiles
5. adding a plugin property jcodemodel.java.feature to transmit it in the plugins

That's it. Nothing else changes, since nothing yet uses it. but now the feature value is visible, modifiable, the default value can be changed easily.