### PR TITLE
Switchexpression for java 17

### DIFF
--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JCodeModel.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JCodeModel.java
@@ -732,6 +732,13 @@ public class JCodeModel implements Serializable
     }
     return aRefClass;
   }
+  
+  ///
+  /// reference a existing enum value
+  public @NonNull JEnumConstantRef ref(Enum<?> e)
+  {
+    return JExpr.enumConstantRef(ref(e.getDeclaringClass()), e.name());
+  }
 
   /**
    * Obtains a reference to a processable class from its TypeElement description.

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JExpr.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JExpr.java
@@ -542,4 +542,8 @@ public final class JExpr
   {
     return JOp.cond (aCond, aIfTrue, aIfFalse);
   }
+
+  public static JSwitchExpression _switch(IJExpression exp) {
+    return new JSwitchExpression(exp);
+  }
 }

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JSwitchExpression.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JSwitchExpression.java
@@ -84,6 +84,7 @@ public class JSwitchExpression implements IJExpressionStatement {
     return c;
   }
 
+// requires j25
 //	@NonNull
 //	public JCasePattern _case(AbstractJType type, String varName) {
 //		JCasePattern c = new JCasePattern(this, type, varName);
@@ -91,14 +92,16 @@ public class JSwitchExpression implements IJExpressionStatement {
 //		return c;
 //	}
 
+// requires j25
 //	@NonNull
 //	public JCasePattern _case(JCodeModel jcm, Class<?> cl, String varName) {
 //		return _case(jcm.ref(cl), varName);
 //	}
 
-  public JCaseSpecialSelector _null() {
-    return new JCaseSpecialSelector(this, true);
-  }
+// requires j21
+//	public JCaseSpecialSelector _null() {
+//		return new JCaseSpecialSelector(this, true);
+//	}
 
   public JCaseSpecialSelector _default() {
     return new JCaseSpecialSelector(this, false);
@@ -106,6 +109,10 @@ public class JSwitchExpression implements IJExpressionStatement {
 
   @Override
   public void generate(@NonNull IJFormatter f) {
+    generate25(f);
+  }
+
+  protected void generate25(@NonNull IJFormatter f) {
     f.print("switch (").generable(m_aTestExpr).print(')').print(" {").newline();
     for (final JCaseArrow<?> c : m_aCases) {
       f.statement(c);
@@ -124,6 +131,12 @@ public class JSwitchExpression implements IJExpressionStatement {
     }
     f.outdent();
     f.print('}').newline();
+  }
+
+  protected void generatePre25(@NonNull IJFormatter f) {
+    // TODO in that case we generate only the static ones ; the pattern cases must
+    // be added on top of the default.
+    throw new UnsupportedOperationException("not implemented yet.");
   }
 
   @Override

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JSwitchExpression.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JSwitchExpression.java
@@ -1,0 +1,134 @@
+package com.helger.jcodemodel;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.jspecify.annotations.NonNull;
+
+import com.helger.jcodemodel.switchexpression.JCaseArrow;
+import com.helger.jcodemodel.switchexpression.JCaseSpecialSelector;
+import com.helger.jcodemodel.switchexpression.JCaseStatic;
+
+///
+/// A switch whose result can be used as an expression or a statement.
+/// basically a copy of [JSwitch]
+/// It has two specific blocks : null and default. When writing those, they should be tested for equality.
+@SuppressWarnings("serial")
+public class JSwitchExpression implements IJExpressionStatement {
+
+  /**
+   * Test part of switch statement.
+   */
+  private final IJExpression m_aTestExpr;
+
+  /**
+   * vector of JCases.
+   */
+  private final List<JCaseArrow<?>> m_aCases = new ArrayList<>();
+
+  /**
+   * a single default block
+   */
+  private JBlock m_aDefaultBlock;
+
+  @NonNull
+  public JBlock defaultBlock() {
+    if (m_aDefaultBlock == null) {
+      m_aDefaultBlock = new JLambdaBlock();
+    }
+    return m_aDefaultBlock;
+  }
+
+  /**
+   * a single null block
+   */
+  private JBlock m_aNullBlock;
+
+  @NonNull
+  public JBlock nullBlock() {
+    if (m_aNullBlock == null) {
+      m_aNullBlock = new JLambdaBlock();
+    }
+    return m_aNullBlock;
+  }
+
+  /**
+   * Construct a switch statement
+   *
+   * @param aTestExpr
+   *                  expression
+   */
+  public JSwitchExpression(@NonNull final IJExpression aTestExpr) {
+    m_aTestExpr = aTestExpr;
+  }
+
+  @NonNull
+  public IJExpression test() {
+    return m_aTestExpr;
+  }
+
+  @NonNull
+  public Iterator<JCaseArrow<?>> cases() {
+    return m_aCases.iterator();
+  }
+
+  public JCaseStatic _case(@NonNull final JEnumConstant constantRef) {
+    return _case(JExpr.enumConstantRef(constantRef.type(), constantRef.name()));
+  }
+
+  @NonNull
+  public JCaseStatic _case(@NonNull final IJExpression aLabel) {
+    JCaseStatic c = new JCaseStatic(this, aLabel);
+    m_aCases.add(c);
+    return c;
+  }
+
+//	@NonNull
+//	public JCasePattern _case(AbstractJType type, String varName) {
+//		JCasePattern c = new JCasePattern(this, type, varName);
+//		m_aCases.add(c);
+//		return c;
+//	}
+
+//	@NonNull
+//	public JCasePattern _case(JCodeModel jcm, Class<?> cl, String varName) {
+//		return _case(jcm.ref(cl), varName);
+//	}
+
+  public JCaseSpecialSelector _null() {
+    return new JCaseSpecialSelector(this, true);
+  }
+
+  public JCaseSpecialSelector _default() {
+    return new JCaseSpecialSelector(this, false);
+  }
+
+  @Override
+  public void generate(@NonNull IJFormatter f) {
+    f.print("switch (").generable(m_aTestExpr).print(')').print(" {").newline();
+    for (final JCaseArrow<?> c : m_aCases) {
+      f.statement(c);
+    }
+    f.indent();
+    if (m_aNullBlock != null && m_aDefaultBlock != null
+        && m_aNullBlock.getContents().equals(m_aDefaultBlock.getContents())) {
+      f.print("case null, default -> ").statement(m_aNullBlock);
+    } else {
+      if (m_aNullBlock != null) {
+        f.print("case null -> ").statement(m_aNullBlock);
+      }
+      if (m_aDefaultBlock != null) {
+        f.print("default -> ").statement(m_aDefaultBlock);
+      }
+    }
+    f.outdent();
+    f.print('}').newline();
+  }
+
+  @Override
+  public void state(@NonNull final IJFormatter f) {
+    f.generable(this).print(';').newline();
+  }
+
+}

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JYield.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JYield.java
@@ -1,0 +1,37 @@
+package com.helger.jcodemodel;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/// copy of JReturn
+public class JYield implements IJStatement {
+  /**
+   * {@link IJExpression} to yield; may be null.
+   */
+  private final IJExpression m_aExpr;
+
+  /**
+   * JYield constructor
+   *
+   * @param aExpr
+   *              {@link IJExpression} which evaluates to yield value
+   */
+  public JYield(@Nullable final IJExpression aExpr) {
+    m_aExpr = aExpr;
+  }
+
+  @Nullable
+  public IJExpression expr() {
+    return m_aExpr;
+  }
+
+  @Override
+  public void state(@NonNull final IJFormatter f) {
+    f.print("yield");
+    if (m_aExpr != null) {
+      f.print(' ').generable(m_aExpr);
+    }
+    f.print(';');
+    f.newline();
+  }
+}

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/switchexpression/BlockSelection.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/switchexpression/BlockSelection.java
@@ -1,0 +1,61 @@
+package com.helger.jcodemodel.switchexpression;
+
+import java.util.Iterator;
+import java.util.List;
+
+import com.helger.jcodemodel.AbstractJType;
+import com.helger.jcodemodel.IJExpression;
+import com.helger.jcodemodel.IJStatement;
+import com.helger.jcodemodel.JBlock;
+import com.helger.jcodemodel.JCodeModel;
+import com.helger.jcodemodel.JExpr;
+import com.helger.jcodemodel.JInvocation;
+import com.helger.jcodemodel.JThrow;
+import com.helger.jcodemodel.JYield;
+
+///
+/// represents a list of blocks to which add statements, with syntaxic sugar for yield. Made specifically for switch (and yield)
+public interface BlockSelection<Self extends BlockSelection<?>> extends Iterable<JBlock> {
+
+  List<JBlock> blocks();
+
+  /// cast this to the template Self type
+  @SuppressWarnings("unchecked")
+  default Self selfThis() {
+    return (Self) this;
+  }
+
+  @Override
+  default Iterator<JBlock> iterator() {
+    return blocks().iterator();
+  }
+
+  default Self add(IJStatement stt) {
+    for (JBlock jb : this) {
+      jb.add(stt);
+    }
+    return selfThis();
+  }
+
+  default Self _throws(JCodeModel owner, Class<? extends Throwable> clazz, IJExpression... params) {
+    return _throws(owner.ref(clazz), params);
+  }
+
+  /// create a new throw
+  default Self _throws(AbstractJType t, IJExpression... params) {
+    JInvocation _new = JExpr._new(t);
+    if (params != null) {
+      for (IJExpression ije : params) {
+        _new.arg(ije);
+      }
+    }
+    add(new JThrow(_new));
+    return selfThis();
+  }
+
+  default Self yield(IJExpression exp) {
+    add(new JYield(exp));
+    return selfThis();
+  }
+
+}

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/switchexpression/JCaseArrow.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/switchexpression/JCaseArrow.java
@@ -1,0 +1,62 @@
+package com.helger.jcodemodel.switchexpression;
+
+import java.util.List;
+
+import com.helger.jcodemodel.IJFormatter;
+import com.helger.jcodemodel.IJObject;
+import com.helger.jcodemodel.IJStatement;
+import com.helger.jcodemodel.JBlock;
+import com.helger.jcodemodel.JLambdaBlock;
+import com.helger.jcodemodel.JSwitchExpression;
+import com.helger.jcodemodel.JThrow;
+import com.helger.jcodemodel.JYield;
+
+///
+/// a switch case using arrow. The case select depends on the implementation
+/// [BlockSelection] allows to chain them, but requires to provide a list of blocks
+@SuppressWarnings("serial")
+public abstract class JCaseArrow<Self extends JCaseArrow<?>> implements IJStatement, BlockSelection<Self> {
+
+  private final JSwitchExpression parent;
+
+  public JCaseArrow(JSwitchExpression parent) {
+    this.parent = parent;
+  }
+
+  public JSwitchExpression up() {
+    return parent;
+  }
+
+  private JLambdaBlock block = new JLambdaBlock();
+
+  public JLambdaBlock getBlock() {
+    return block;
+  }
+
+  private List<JBlock> blocks = List.of(block);
+
+  @Override
+  public List<JBlock> blocks() {
+    return blocks;
+  }
+
+  /// generate the arrow and body in the formatter
+  protected void stateBody(IJFormatter f) {
+    f.print(" -> ").newline();
+    if (block.getContents().size() == 1) {
+      IJObject firstContent = block.getContents().get(0);
+      if (firstContent instanceof JYield jy) {
+        f.indent();
+        f.generable(jy.expr()).print(";").newline();
+        f.outdent();
+        return;
+      } else if (firstContent instanceof JThrow jt) {
+        f.indent();
+        f.statement(jt);
+        f.outdent();
+        return;
+      }
+    }
+    f.statement(getBlock());
+  }
+}

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/switchexpression/JCasePattern.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/switchexpression/JCasePattern.java
@@ -75,7 +75,6 @@ public class JCasePattern extends JCaseArrow<JCasePattern> {
     }
     stateBody(f);
     f.outdent();
-
   }
 
 

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/switchexpression/JCasePattern.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/switchexpression/JCasePattern.java
@@ -1,0 +1,82 @@
+package com.helger.jcodemodel.switchexpression;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import org.jspecify.annotations.NonNull;
+
+import com.helger.jcodemodel.AbstractJType;
+import com.helger.jcodemodel.IJExpression;
+import com.helger.jcodemodel.IJFormatter;
+import com.helger.jcodemodel.IJStatement;
+import com.helger.jcodemodel.JLambdaParam;
+import com.helger.jcodemodel.JSwitchExpression;
+import com.helger.jcodemodel.JThrow;
+
+/// switch case using a pattern as the selection. require java feature >= 21
+/// ```
+/// 	case char c when c>='&' && c<='z'-> {countChars++; yield 1+c-'a';}
+/// ```
+@SuppressWarnings("serial")
+public class JCasePattern extends JCaseArrow<JCasePattern> {
+
+  private final AbstractJType type;
+
+  private final String varName;
+
+  public JCasePattern(JSwitchExpression parent, AbstractJType type, String varName) {
+    super(parent);
+    this.type = type;
+    this.varName = varName;
+  }
+
+  private final List<IJExpression> guards = new ArrayList<>();
+
+  public JCasePattern when(Function<JLambdaParam, IJExpression> maker) {
+    guards.add(maker.apply(param()));
+    return this;
+  }
+
+  private JLambdaParam param = null;
+
+  public JLambdaParam param() {
+    if (param == null) {
+      param = new JLambdaParam(type, varName);
+    }
+    return param;
+  }
+
+  public JCasePattern addOn(Function<JLambdaParam, IJStatement> maker) {
+    return add(maker.apply(param()));
+  }
+
+  public JCasePattern _throwsOn(Function<JLambdaParam, IJExpression> maker) {
+    return add(new JThrow(maker.apply(param())));
+  }
+
+  public JCasePattern yieldOn(Function<JLambdaParam, IJExpression> maker) {
+    return super.yield(maker.apply(param()));
+  }
+
+  @Override
+  public void state(@NonNull IJFormatter f) {
+    f.indent();
+    f.print("case ").declaration(param);
+    boolean first = true;
+    for (IJExpression ije : guards) {
+      if (first) {
+        f.print(" when ");
+      } else {
+        f.print(" && ");
+      }
+      f.generable(ije);
+      first = false;
+    }
+    stateBody(f);
+    f.outdent();
+
+  }
+
+
+}

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/switchexpression/JCaseSpecialSelector.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/switchexpression/JCaseSpecialSelector.java
@@ -1,0 +1,42 @@
+package com.helger.jcodemodel.switchexpression;
+
+import java.util.List;
+
+import com.helger.jcodemodel.JBlock;
+import com.helger.jcodemodel.JSwitchExpression;
+
+///
+/// specify the special `case null` and `default` in a switch expression
+///
+
+public class JCaseSpecialSelector implements BlockSelection<JCaseSpecialSelector> {
+
+  private boolean setDefault = false;
+
+  private boolean setNull = false;
+
+  private final JSwitchExpression parent;
+
+  public JCaseSpecialSelector(JSwitchExpression parent, boolean isNull) {
+    this.parent = parent;
+    setDefault = !isNull;
+    setNull = isNull;
+  }
+
+  public JCaseSpecialSelector andDefault() {
+    setDefault = true;
+    return this;
+  }
+
+  public JCaseSpecialSelector andNull() {
+    setNull = true;
+    return this;
+  }
+
+  @Override
+  public List<JBlock> blocks() {
+    return setDefault && setNull ? List.of(parent.defaultBlock(), parent.nullBlock())
+        : List.of(setDefault ? parent.defaultBlock() : parent.nullBlock());
+  }
+
+}

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/switchexpression/JCaseSpecialSelector.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/switchexpression/JCaseSpecialSelector.java
@@ -28,10 +28,11 @@ public class JCaseSpecialSelector implements BlockSelection<JCaseSpecialSelector
     return this;
   }
 
-  public JCaseSpecialSelector andNull() {
-    setNull = true;
-    return this;
-  }
+// requires j21
+//	public JCaseSpecialSelector andNull() {
+//		setNull = true;
+//		return this;
+//	}
 
   @Override
   public List<JBlock> blocks() {

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/switchexpression/JCaseStatic.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/switchexpression/JCaseStatic.java
@@ -1,0 +1,65 @@
+package com.helger.jcodemodel.switchexpression;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jspecify.annotations.NonNull;
+
+import com.helger.jcodemodel.IJExpression;
+import com.helger.jcodemodel.IJFormatter;
+import com.helger.jcodemodel.JEnumConstant;
+import com.helger.jcodemodel.JSwitchExpression;
+
+///
+/// Switch case using static value(s) for selection
+/// ```
+/// case 1,3 ->
+/// case MyEnum.OPT1 ->
+/// ```
+@SuppressWarnings("serial")
+public class JCaseStatic extends JCaseArrow<JCaseStatic> {
+
+  private final List<IJExpression> labels;
+
+  public JCaseStatic(@NonNull JSwitchExpression parent, IJExpression aLabel) {
+    super(parent);
+    labels = new ArrayList<>(List.of(aLabel));
+  }
+
+  /// add a label to the list of existing ones
+  public JCaseStatic or(IJExpression aLabel) {
+    labels.add(aLabel);
+    return this;
+  }
+
+  /// alias for [#or]
+  public JCaseStatic _case(IJExpression aLabel) {
+    return or(aLabel);
+  }
+
+  /// copy of [JCase]
+  @Override
+  public void state(@NonNull final IJFormatter f) {
+    f.indent();
+    f.print("case ");
+    boolean first = true;
+    for (IJExpression ije : labels) {
+      IJExpression aLabelName;
+      // Hack for #41 :)
+      if (ije instanceof JEnumConstant) {
+        // Just use the name, but not the type of the enum
+        aLabelName = f1 -> f1.print(((JEnumConstant) ije).name());
+      } else {
+        aLabelName = ije;
+      }
+      if (!first) {
+        f.print(", ");
+      }
+      f.generable(aLabelName);
+      first = false;
+    }
+    stateBody(f);
+    f.outdent();
+  }
+
+}

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/switchexpression/JCaseStatic.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/switchexpression/JCaseStatic.java
@@ -8,6 +8,7 @@ import org.jspecify.annotations.NonNull;
 import com.helger.jcodemodel.IJExpression;
 import com.helger.jcodemodel.IJFormatter;
 import com.helger.jcodemodel.JEnumConstant;
+import com.helger.jcodemodel.JEnumConstantRef;
 import com.helger.jcodemodel.JSwitchExpression;
 
 ///
@@ -49,6 +50,9 @@ public class JCaseStatic extends JCaseArrow<JCaseStatic> {
       if (ije instanceof JEnumConstant) {
         // Just use the name, but not the type of the enum
         aLabelName = f1 -> f1.print(((JEnumConstant) ije).name());
+      } else if (ije instanceof JEnumConstantRef) {
+        // Just use the name, but not the type of the enum
+        aLabelName = f1 -> f1.print(((JEnumConstantRef) ije).name());
       } else {
         aLabelName = ije;
       }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/switchexpression/BasicSwitch.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/switchexpression/BasicSwitch.java
@@ -3,7 +3,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- * 				http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,9 @@
  */
 package com.helger.jcodemodel.tests.switchexpression;
 
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
 public class BasicSwitch {
 
     public static boolean isOdd(int i) {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/switchexpression/BasicSwitch.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/switchexpression/BasicSwitch.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.helger.jcodemodel.tests.switchexpression;
+
+public class BasicSwitch {
+
+    public static boolean isOdd(int i) {
+        return switch (i) {
+            case  0,  2  -> 
+                false;
+            case  1,  3  -> 
+                true;
+            case  4,  5,  6,  7,  8,  9  -> 
+                isOdd((i - 2));
+            default -> {
+                throw new UnsupportedOperationException(("case not handled : "+ i));
+            }
+        }
+        ;
+    }
+}

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/switchexpression/EPeriod.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/switchexpression/EPeriod.java
@@ -3,7 +3,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- * 				http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,9 @@
  */
 package com.helger.jcodemodel.tests.switchexpression;
 
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
 public enum EPeriod {
     YEAR,
     WEEK,

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/switchexpression/EPeriod.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/switchexpression/EPeriod.java
@@ -1,0 +1,21 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.helger.jcodemodel.tests.switchexpression;
+
+public enum EPeriod {
+    YEAR,
+    WEEK,
+    MONTH;
+}

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/switchexpression/ESwitch.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/switchexpression/ESwitch.java
@@ -3,7 +3,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- * 				http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,9 @@
  */
 package com.helger.jcodemodel.tests.switchexpression;
 
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
 public class ESwitch {
 
     public static int daysIn(EnumMonths em) {

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/switchexpression/ESwitch.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/switchexpression/ESwitch.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.helger.jcodemodel.tests.switchexpression;
+
+public class ESwitch {
+
+    public static int daysIn(EnumMonths em) {
+        return switch (em) {
+            case JAN, MAR -> 
+                31;
+            case FEB -> 
+                28;
+            default -> {
+                throw new UnsupportedOperationException();
+            }
+        }
+        ;
+    }
+
+    public static int daysIn(EPeriod ep) {
+        return switch (ep) {
+            case YEAR -> 
+                365;
+            case WEEK -> 
+                7;
+            case MONTH -> 
+                throw new UnsupportedOperationException("a month can have 28, 30 or 31 days.");
+            default -> {
+                throw new UnsupportedOperationException();
+            }
+        }
+        ;
+    }
+}

--- a/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/switchexpression/EnumMonths.java
+++ b/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/switchexpression/EnumMonths.java
@@ -1,0 +1,7 @@
+package com.helger.jcodemodel.tests.switchexpression;
+
+public enum EnumMonths {
+
+  JAN, FEB, MAR, APR;
+
+}

--- a/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/switchexpression/SwitchExpressionTestGen.java
+++ b/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/switchexpression/SwitchExpressionTestGen.java
@@ -1,0 +1,61 @@
+package com.helger.jcodemodel.tests.switchexpression;
+
+import com.helger.jcodemodel.*;
+import com.helger.jcodemodel.compile.annotation.TestJCM;
+import com.helger.jcodemodel.exceptions.JCodeModelException;
+
+@TestJCM
+public class SwitchExpressionTestGen {
+
+  public void basicSwitch(JPackage root, JCodeModel jcm) throws JCodeModelException {
+    JDefinedClass cl = root._class("BasicSwitch");
+  JMethod m = cl.method(JMod.PUBLIC | JMod.STATIC, boolean.class, "isOdd");
+  JVar i = m.param(jcm.INT, "i");
+    JSwitchExpression sw = JExpr._switch(i);
+
+  sw._case(JExpr.lit(0))._case(JExpr.lit(2)).yield(JExpr.FALSE);
+  sw._case(JExpr.lit(1))._case(JExpr.lit(3)).yield(JExpr.TRUE);
+  sw._case(JExpr.lit(4))
+      ._case(JExpr.lit(5))
+      ._case(JExpr.lit(6))
+      ._case(JExpr.lit(7))
+      ._case(JExpr.lit(8))
+      ._case(JExpr.lit(9))
+      .yield(JExpr.invoke(m).arg(JOp.minus(i, JExpr.lit(2))));
+    sw._default()._throws(jcm, UnsupportedOperationException.class, JOp.plus(JExpr.lit("case not handled : "), i));
+
+    // java 17
+    // return switch(o){ … };
+    m.body()._return(sw);
+  }
+
+  public void switchEnum(JPackage root, JCodeModel jcm) throws JCodeModelException {
+    JDefinedClass cl = root._class("ESwitch");
+  JMethod m1 = cl.method(JMod.PUBLIC | JMod.STATIC, jcm.INT, "daysIn");
+  JVar o = m1.param(jcm.ref(EnumMonths.class), "em");
+    JSwitchExpression sw = JExpr._switch(o);
+    m1.body()._return(sw);
+  sw._default()
+  // requires j21
+//    .andNull()
+      ._throws(jcm, UnsupportedOperationException.class);
+    sw._case(jcm.ref(EnumMonths.JAN))
+        .or(jcm.ref(EnumMonths.MAR))
+        .yield(JExpr.lit(31));
+    sw._case(jcm.ref(EnumMonths.FEB)).yield(JExpr.lit(28));
+
+    JDefinedClass ep = root._enum("EPeriod");
+    JEnumConstant yearConstant = ep.enumConstant("YEAR");
+  JMethod m2 = cl.method(JMod.PUBLIC | JMod.STATIC, jcm.INT, "daysIn");
+  o = m2.param(ep, "ep");
+  sw = JExpr._switch(o);
+  m2.body()._return(sw);
+    sw._case(yearConstant).yield(JExpr.lit(365));
+    sw._case(ep.enumConstant("WEEK")).yield(JExpr.lit(7));
+    sw._case(ep.enumConstant("MONTH"))._throws(jcm, UnsupportedOperationException.class,
+        JExpr.lit("a month can have 28, 30 or 31 days."));
+  sw._default()
+      ._throws(jcm, UnsupportedOperationException.class);
+  }
+
+}

--- a/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/switchexpression/SwitchExpressionTest.java
+++ b/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/switchexpression/SwitchExpressionTest.java
@@ -1,0 +1,26 @@
+package com.helger.jcodemodel.tests.switchexpression;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SwitchExpressionTest {
+
+  @Test
+  public void basicSwitch() {
+    Assert.assertFalse(BasicSwitch.isOdd(0));
+    Assert.assertTrue(BasicSwitch.isOdd(1));
+    Assert.assertFalse(BasicSwitch.isOdd(6));
+    Assert.assertThrows(UnsupportedOperationException.class, () -> BasicSwitch.isOdd(42));
+  }
+
+  @Test
+  public void switchEnum() {
+    Assert.assertEquals(31, ESwitch.daysIn(EnumMonths.JAN));
+    Assert.assertEquals(28, ESwitch.daysIn(EnumMonths.FEB));
+
+    Assert.assertEquals(7, ESwitch.daysIn(EPeriod.WEEK));
+    Assert.assertEquals(365, ESwitch.daysIn(EPeriod.YEAR));
+    Assert.assertThrows(UnsupportedOperationException.class, () -> ESwitch.daysIn(EPeriod.MONTH));
+  }
+
+}


### PR DESCRIPTION
integrate only java14 switch expression, but ready to add the 21 null and 25 pattern. 
Import most code from the other switchexpression branch, but does not change java version.

The class to add the null  and pattern are still present, but the methods to add them are commented.

this allows to generate
https://github.com/glelouet/jcodemodel/blob/switchexpression17/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/switchexpression/ESwitch.java
https://github.com/glelouet/jcodemodel/blob/switchexpression17/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/switchexpression/BasicSwitch.java

from
https://github.com/glelouet/jcodemodel/blob/switchexpression17/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/switchexpression/SwitchExpressionTestGen.java

