### PR TITLE
text blocks

### DIFF
--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JExpr.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JExpr.java
@@ -504,6 +504,18 @@ public final class JExpr
   {
     return new JStringLiteral (sStr);
   }
+  
+  @NonNull
+  public static JTextBlock textBlock (@NonNull final String sStr)
+  {
+    return new JTextBlock (sStr);
+  }
+  
+  @NonNull
+  public static JTextBlock textBlock ()
+  {
+    return new JTextBlock ();
+  }
 
   /**
    * Creates an aExpr directly from a source code fragment.

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JExpr.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JExpr.java
@@ -40,6 +40,8 @@
  */
 package com.helger.jcodemodel;
 
+import java.util.stream.Stream;
+
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -506,15 +508,12 @@ public final class JExpr
   }
   
   @NonNull
-  public static JTextBlock textBlock (@NonNull final String sStr)
+  public static JTextBlock textBlock (@NonNull final String ... lines)
   {
-    return new JTextBlock (sStr);
-  }
-  
-  @NonNull
-  public static JTextBlock textBlock ()
-  {
-    return new JTextBlock ();
+    JTextBlock ret = new JTextBlock();
+    if(lines!=null && lines.length!=0)
+      Stream.of(lines).forEach(ret::add);
+    return ret;
   }
 
   /**

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
@@ -34,9 +34,12 @@ public class JTextBlock implements IJExpression, Iterable<String> {
     return
         line
             // escape triple parenthesis
-            .replace("\"\"\"", "\\\"\"\"")
-            // trailing spaces/tabs are stripped : replace last with octal space
-            .replaceAll("[ \t]$", "\\\\040");
+            .replace("\"\"\"", "\\\"\"\\\"")
+            // trailing spaces/tabs are stripped : replace last space octal space (ascii d32
+            // = o040 )
+            .replaceAll(" $", "\\\\040")
+            // and last tab with octal tab (ascii d9 = o011 )
+            .replaceAll("\t$", "\\\\011");
   }
 
   private int indentSize = 0;
@@ -130,7 +133,7 @@ public class JTextBlock implements IJExpression, Iterable<String> {
       lastEmpty = line.isEmpty();
     }
     f.print(LIMITER);
-    if (!lastEmpty) {
+    if (!lastEmpty && indentSize > 0) {
       // if the last line is not empty, then the delimiter is not enough to enforce
       // the indent. So we add a call after that.
       f

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
@@ -1,0 +1,143 @@
+package com.helger.jcodemodel;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.jspecify.annotations.NonNull;
+
+/// Represents a text block declaration, one line at a time.
+///
+/// [https://docs.oracle.com/en/java/javase/26/language/text-blocks.html]
+///
+@SuppressWarnings("serial")
+public class JTextBlock implements IJExpression, Iterable<String> {
+
+  public JTextBlock() {
+  }
+
+  public JTextBlock(String value) {
+    add(value);
+  }
+
+  /// convert a user line into several individual text block lines.
+  static Stream<String> formatLines(String line) {
+    return line.lines()
+        .map(JTextBlock::formatLine);
+
+  }
+
+  /// format a standard String line to make it a text block line.
+  static String formatLine(String line) {
+    return
+        line
+            // escape triple parenthesis
+            .replace("\"\"\"", "\\\"\"\"")
+            // trailing spaces/tabs are stripped : replace last with octal space
+            .replaceAll("[ \t]$", "\\\\040");
+  }
+
+  private int indentSize = 0;
+
+  public JTextBlock indentSize(int val) {
+    indentSize = val;
+    return this;
+  }
+
+  public int indentSize() {
+    return indentSize;
+  }
+
+  private char indentChar = ' ';
+
+  public JTextBlock indentChar(char val) {
+    if (val != ' ' && val != '\t') {
+      throw new UnsupportedOperationException("escape char must be space or tab");
+    }
+    indentChar = val;
+    return this;
+  }
+
+  public JTextBlock indentSpace() {
+    return indentChar(' ');
+  }
+
+  public JTextBlock indentTab() {
+    return indentChar('\t');
+  }
+
+  public char indentChar() {
+    return indentChar;
+  }
+
+  private List<String> lines = new ArrayList<>();
+
+  ///
+  /// transforms a line to make it fit to the text block syntax.
+  ///
+  /// @param line if null nothing happens
+  public JTextBlock add(String line) {
+    if (line != null) {
+      formatLines(line).forEach(lines::add);
+    }
+    return this;
+  }
+
+  /// shortcut to add a new line
+  public JTextBlock newline() {
+    lines.add("");
+    return this;
+  }
+
+  /// shortcut to add new lines
+  /// if i<1 no new line is added
+  public JTextBlock newlines(int nb) {
+    for (int i = 0; i < nb; i++) {
+      newline();
+    }
+    return this;
+  }
+
+  /// unmodifiable iterator over the internal lines
+  @Override
+  public Iterator<String> iterator() {
+    return Collections.unmodifiableList(lines).iterator();
+  }
+
+  public Stream<String> lines() {
+    return lines.stream();
+  }
+
+  private static final String LIMITER = "\"\"\"";
+
+  @Override
+  public void generate(@NonNull IJFormatter f) {
+    f.print(LIMITER).newline();
+    String indent =
+        indentSize <= 0 || lines.isEmpty()
+            ? ""
+            : ("" + indentChar).repeat(indentSize);
+    boolean first = true;
+    boolean lastEmpty = true;
+    for (String line : lines) {
+      if (!first) {
+        f.newline();
+      }
+      f.print(indent).print(line);
+      first = false;
+      lastEmpty = line.isEmpty();
+    }
+    f.print(LIMITER);
+    if (!lastEmpty) {
+      // if the last line is not empty, then the delimiter is not enough to enforce
+      // the indent. So we add a call after that.
+      f
+          .print(".indent(")
+          .print("" + indentSize)
+          .print(")");
+    }
+  }
+
+}

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
@@ -15,6 +15,12 @@ import org.jspecify.annotations.NonNull;
 @SuppressWarnings("serial")
 public class JTextBlock implements IJExpression, Iterable<String> {
 
+  private char indentChar = ' ';
+
+  private int indentSize = 0;
+
+  private List<String> lines = new ArrayList<>();
+
   public JTextBlock() {
   }
 
@@ -52,8 +58,6 @@ public class JTextBlock implements IJExpression, Iterable<String> {
         .replaceAll("([^\\\\])\"$", "$1\\\\\"");
   }
 
-  private int indentSize = 0;
-
   public JTextBlock indentSize(int val) {
     indentSize = val;
     return this;
@@ -62,8 +66,6 @@ public class JTextBlock implements IJExpression, Iterable<String> {
   public int indentSize() {
     return indentSize;
   }
-
-  private char indentChar = ' ';
 
   public JTextBlock indentChar(char val) {
     if (val != ' ' && val != '\t') {
@@ -85,7 +87,6 @@ public class JTextBlock implements IJExpression, Iterable<String> {
     return indentChar;
   }
 
-  private List<String> lines = new ArrayList<>();
 
   ///
   /// transforms a line to make it fit to the text block syntax.
@@ -134,7 +135,7 @@ public class JTextBlock implements IJExpression, Iterable<String> {
     String indent =
         indentSize <= 0 || lines.isEmpty()
             ? ""
-            : ("" + indentChar).repeat(indentSize);
+            : Character.toString(indentChar).repeat(indentSize);
     boolean first = true;
     boolean lastEmpty = true;
     // the last line must not end with unescaped doublequote

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
@@ -10,6 +10,20 @@ import org.jspecify.annotations.NonNull;
 
 /// Represents a text block declaration, one line at a time.
 ///
+///
+///
+/// ## doublequote escaping
+///
+/// triple doublequotes `"""` are escaped by having the third one backslashed `""\"`.
+/// Plus, if the last line ends with an unescaped doublequote, this doublequote is escaped to avoid breaking the parser.
+///
+/// ## keepWhiteSpaces
+///
+/// The output of the lines differ depending on [#keepWhitespaces]
+///  - when false(default), the content of the file will be the one added.
+///  - when true, the content of the resulting string will be the one added
+/// In the later, if all lines start with a whitespace, then all starting whitespace are set to otal ; plus all ending whitespace are also set to octal.
+///
 /// [https://docs.oracle.com/en/java/javase/26/language/text-blocks.html]
 ///
 @SuppressWarnings("serial")
@@ -20,6 +34,8 @@ public class JTextBlock implements IJExpression, Iterable<String> {
   private int indentSize = 0;
 
   private List<String> lines = new ArrayList<>();
+
+  private boolean keepWhitespaces = false;
 
   public JTextBlock() {
   }
@@ -39,12 +55,7 @@ public class JTextBlock implements IJExpression, Iterable<String> {
   static String formatLine(String line) {
     return line
         // escape triple parenthesis
-        .replace("\"\"\"", "\"\"\\\"")
-        // trailing spaces/tabs are stripped : replace last space octal space (ascii d32
-        // = o040 )
-        .replaceAll(" $", "\\\\040")
-        // and last tab with octal tab (ascii d9 = o011 )
-        .replaceAll("\t$", "\\\\011");
+        .replace("\"\"\"", "\"\"\\\"");
   }
 
   static String escapeLastIfDoubleQuote(String s) {
@@ -58,15 +69,18 @@ public class JTextBlock implements IJExpression, Iterable<String> {
         .replaceAll("([^\\\\])\"$", "$1\\\\\"");
   }
 
+  /// @return this, to chain
   public JTextBlock indentSize(int val) {
     indentSize = val;
     return this;
   }
 
+  /// @return this, to chain
   public int indentSize() {
     return indentSize;
   }
 
+  /// @return this, to chain
   public JTextBlock indentChar(char val) {
     if (val != ' ' && val != '\t') {
       throw new UnsupportedOperationException("escape char must be space or tab");
@@ -75,18 +89,30 @@ public class JTextBlock implements IJExpression, Iterable<String> {
     return this;
   }
 
+  /// @return this, to chain
   public JTextBlock indentSpace() {
     return indentChar(' ');
   }
 
+  /// @return this, to chain
   public JTextBlock indentTab() {
     return indentChar('\t');
   }
 
+  /// @return this, to chain
   public char indentChar() {
     return indentChar;
   }
 
+  /// @return this, to chain
+  public JTextBlock keepWhitespaces(boolean verbatim) {
+    keepWhitespaces = verbatim;
+    return this;
+  }
+
+  public boolean keepWhitespaces() {
+    return keepWhitespaces;
+  }
 
   ///
   /// transforms a line to make it fit to the text block syntax.
@@ -138,11 +164,10 @@ public class JTextBlock implements IJExpression, Iterable<String> {
             : Character.toString(indentChar).repeat(indentSize);
     boolean firstLine = true;
     boolean lastEmpty = true;
-    // don't modify the internal list.
+    // don't modify the internal list : work on a copy if modification required.
     List<String> modifiedLines = lines;
     // the last line must not end with unescaped doublequote
-    // if escaping its last parentheses produces a different String, then we copy
-    // the full list to not modify the existing one.
+    // if that's the case, we copy the full list to not modify the existing one.
     if (!modifiedLines.isEmpty()) {
       String lastLine = modifiedLines.get(modifiedLines.size() - 1);
       String escapedLastLine = escapeLastIfDoubleQuote(lastLine);
@@ -151,9 +176,30 @@ public class JTextBlock implements IJExpression, Iterable<String> {
         modifiedLines.set(modifiedLines.size() - 1, escapedLastLine);
       }
     }
+    // we need to escape starting whitespaces iff we are verbatim and all lines
+    // start with space or tab
+    boolean requireEscapeStart =
+        keepWhitespaces
+            && modifiedLines.stream()
+                .filter(l -> !l.startsWith(" ") && !l.startsWith("\t"))
+                .findAny().isEmpty();
     for (String line : modifiedLines) {
       if (!firstLine) {
         f.newline();
+      }
+      if (requireEscapeStart) {
+        // replace starting space/tab by octal
+        line =
+            line
+                .replaceAll("^ ", "\\\\040")
+                .replaceAll("^\t", "\\\\011");
+      }
+      if (keepWhitespaces) {
+        // replace ending space/tab by octal
+        line =
+            line
+                .replaceAll(" $", "\\\\040")
+                .replaceAll("\t$", "\\\\011");
       }
       f.print(indent).print(line);
       firstLine = false;

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
@@ -31,15 +31,25 @@ public class JTextBlock implements IJExpression, Iterable<String> {
 
   /// format a standard String line to make it a text block line.
   static String formatLine(String line) {
-    return
-        line
-            // escape triple parenthesis
-            .replace("\"\"\"", "\\\"\"\\\"")
-            // trailing spaces/tabs are stripped : replace last space octal space (ascii d32
-            // = o040 )
-            .replaceAll(" $", "\\\\040")
-            // and last tab with octal tab (ascii d9 = o011 )
-            .replaceAll("\t$", "\\\\011");
+    return line
+        // escape triple parenthesis
+        .replace("\"\"\"", "\"\"\\\"")
+        // trailing spaces/tabs are stripped : replace last space octal space (ascii d32
+        // = o040 )
+        .replaceAll(" $", "\\\\040")
+        // and last tab with octal tab (ascii d9 = o011 )
+        .replaceAll("\t$", "\\\\011");
+  }
+
+  static String escapeLastIfDoubleQuote(String s) {
+    if (s == null) {
+      return null;
+    }
+    if (s.equals("\"")) {
+      return "\\\"";
+    }
+    return s
+        .replaceAll("([^\\\\])\"$", "$1\\\\\"");
   }
 
   private int indentSize = 0;
@@ -81,6 +91,7 @@ public class JTextBlock implements IJExpression, Iterable<String> {
   /// transforms a line to make it fit to the text block syntax.
   ///
   /// @param line if null nothing happens
+  /// @return this, to chain
   public JTextBlock add(String line) {
     if (line != null) {
       formatLines(line).forEach(lines::add);
@@ -88,14 +99,16 @@ public class JTextBlock implements IJExpression, Iterable<String> {
     return this;
   }
 
-  /// shortcut to add a new line
+  /// shortcut to add an empty line
+  /// @return this, to chain
   public JTextBlock newline() {
     lines.add("");
     return this;
   }
 
-  /// shortcut to add new lines
-  /// if i<1 no new line is added
+  /// shortcut to add empty lines
+  /// @param nb when <1 nothing happens
+  /// @return this, to chain
   public JTextBlock newlines(int nb) {
     for (int i = 0; i < nb; i++) {
       newline();
@@ -124,6 +137,11 @@ public class JTextBlock implements IJExpression, Iterable<String> {
             : ("" + indentChar).repeat(indentSize);
     boolean first = true;
     boolean lastEmpty = true;
+    // the last line must not end with unescaped doublequote
+    if (!lines.isEmpty()) {
+      String lastLine = lines.get(lines.size() - 1);
+      lines.set(lines.size() - 1, escapeLastIfDoubleQuote(lastLine));
+    }
     for (String line : lines) {
       if (!first) {
         f.newline();

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
@@ -136,19 +136,27 @@ public class JTextBlock implements IJExpression, Iterable<String> {
         indentSize <= 0 || lines.isEmpty()
             ? ""
             : Character.toString(indentChar).repeat(indentSize);
-    boolean first = true;
+    boolean firstLine = true;
     boolean lastEmpty = true;
+    // don't modify the internal list.
+    List<String> modifiedLines = lines;
     // the last line must not end with unescaped doublequote
-    if (!lines.isEmpty()) {
-      String lastLine = lines.get(lines.size() - 1);
-      lines.set(lines.size() - 1, escapeLastIfDoubleQuote(lastLine));
+    // if escaping its last parentheses produces a different String, then we copy
+    // the full list to not modify the existing one.
+    if (!modifiedLines.isEmpty()) {
+      String lastLine = modifiedLines.get(modifiedLines.size() - 1);
+      String escapedLastLine = escapeLastIfDoubleQuote(lastLine);
+      if (!escapedLastLine.equals(lastLine)) {
+        modifiedLines = new ArrayList<>(lines);
+        modifiedLines.set(modifiedLines.size() - 1, escapedLastLine);
+      }
     }
-    for (String line : lines) {
-      if (!first) {
+    for (String line : modifiedLines) {
+      if (!firstLine) {
         f.newline();
       }
       f.print(indent).print(line);
-      first = false;
+      firstLine = false;
       lastEmpty = line.isEmpty();
     }
     f.print(LIMITER);

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JTextBlockTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JTextBlockTest.java
@@ -6,18 +6,10 @@ import org.junit.Test;
 public class JTextBlockTest {
 
   @Test
-  public void testFormat() {
-    // 6 parenthesis should have the first and 4th one escaped
+  public void testFormatLine() {
+    // 6 parenthesis should have the 3rd and 6th one escaped
     Assert.assertEquals("\"\"\\\"\"\"\\\"", JTextBlock.formatLine("\"".repeat(6)));
     Assert.assertEquals("\"\"\\\"?\"\"\\\"", JTextBlock.formatLine("\"".repeat(3) + "?" + "\"".repeat(3)));
-    // end space is octal space
-    Assert.assertEquals("   \\040", JTextBlock.formatLine(" ".repeat(4)));
-    // end tab is octal space
-    Assert.assertEquals(" \\011", JTextBlock.formatLine(" \t"));
-    // same but with alternating space and tabs
-    Assert.assertEquals(" \t \t \\011", JTextBlock.formatLine(" \t".repeat(3)));
-    // same but with alternating tabs and spaces
-    Assert.assertEquals("\t \t \t\\040", JTextBlock.formatLine("\t ".repeat(3)));
   }
 
   @Test
@@ -32,7 +24,7 @@ public class JTextBlockTest {
     JTextBlock test = new JTextBlock();
     test.add("a\n b ");
     Assert.assertTrue(test.lines().filter(l -> l.equals("a")).findAny().isPresent());
-    Assert.assertTrue(test.lines().filter(l -> l.equals(" b\\040")).findAny().isPresent());
+    Assert.assertTrue(test.lines().filter(l -> l.equals(" b ")).findAny().isPresent());
     Assert.assertEquals(2L, test.lines().count());
   }
 

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JTextBlockTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JTextBlockTest.java
@@ -8,8 +8,8 @@ public class JTextBlockTest {
   @Test
   public void testFormat() {
     // 6 parenthesis should have the first and 4th one escaped
-    Assert.assertEquals("\\\"\"\\\"\\\"\"\\\"", JTextBlock.formatLine("\"".repeat(6)));
-    Assert.assertEquals("\\\"\"\\\"?\\\"\"\\\"", JTextBlock.formatLine("\"".repeat(3) + "?" + "\"".repeat(3)));
+    Assert.assertEquals("\"\"\\\"\"\"\\\"", JTextBlock.formatLine("\"".repeat(6)));
+    Assert.assertEquals("\"\"\\\"?\"\"\\\"", JTextBlock.formatLine("\"".repeat(3) + "?" + "\"".repeat(3)));
     // end space is octal space
     Assert.assertEquals("   \\040", JTextBlock.formatLine(" ".repeat(4)));
     // end tab is octal space
@@ -18,6 +18,13 @@ public class JTextBlockTest {
     Assert.assertEquals(" \t \t \\011", JTextBlock.formatLine(" \t".repeat(3)));
     // same but with alternating tabs and spaces
     Assert.assertEquals("\t \t \t\\040", JTextBlock.formatLine("\t ".repeat(3)));
+  }
+
+  @Test
+  public void testEscapeLastIfDoubleQuote() {
+    Assert.assertEquals("", JTextBlock.escapeLastIfDoubleQuote(""));
+    Assert.assertEquals("\\\"", JTextBlock.escapeLastIfDoubleQuote("\""));
+    Assert.assertEquals("\"\\\"", JTextBlock.escapeLastIfDoubleQuote("\"\""));
   }
 
   @Test

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JTextBlockTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JTextBlockTest.java
@@ -8,14 +8,14 @@ public class JTextBlockTest {
   @Test
   public void testFormat() {
     // 6 parenthesis should have the first and 4th one escaped
-    Assert.assertEquals("\\\"\"\"\\\"\"\"", JTextBlock.formatLine("\"".repeat(6)));
-    Assert.assertEquals("\\\"\"\"?\\\"\"\"", JTextBlock.formatLine("\"".repeat(3) + "?" + "\"".repeat(3)));
+    Assert.assertEquals("\\\"\"\\\"\\\"\"\\\"", JTextBlock.formatLine("\"".repeat(6)));
+    Assert.assertEquals("\\\"\"\\\"?\\\"\"\\\"", JTextBlock.formatLine("\"".repeat(3) + "?" + "\"".repeat(3)));
     // end space is octal space
     Assert.assertEquals("   \\040", JTextBlock.formatLine(" ".repeat(4)));
     // end tab is octal space
-    Assert.assertEquals(" \\040", JTextBlock.formatLine(" \t"));
+    Assert.assertEquals(" \\011", JTextBlock.formatLine(" \t"));
     // same but with alternating space and tabs
-    Assert.assertEquals(" \t \t \\040", JTextBlock.formatLine(" \t".repeat(3)));
+    Assert.assertEquals(" \t \t \\011", JTextBlock.formatLine(" \t".repeat(3)));
     // same but with alternating tabs and spaces
     Assert.assertEquals("\t \t \t\\040", JTextBlock.formatLine("\t ".repeat(3)));
   }

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JTextBlockTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JTextBlockTest.java
@@ -1,0 +1,32 @@
+package com.helger.jcodemodel;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JTextBlockTest {
+
+  @Test
+  public void testFormat() {
+    // 6 parenthesis should have the first and 4th one escaped
+    Assert.assertEquals("\\\"\"\"\\\"\"\"", JTextBlock.formatLine("\"".repeat(6)));
+    Assert.assertEquals("\\\"\"\"?\\\"\"\"", JTextBlock.formatLine("\"".repeat(3) + "?" + "\"".repeat(3)));
+    // end space is octal space
+    Assert.assertEquals("   \\040", JTextBlock.formatLine(" ".repeat(4)));
+    // end tab is octal space
+    Assert.assertEquals(" \\040", JTextBlock.formatLine(" \t"));
+    // same but with alternating space and tabs
+    Assert.assertEquals(" \t \t \\040", JTextBlock.formatLine(" \t".repeat(3)));
+    // same but with alternating tabs and spaces
+    Assert.assertEquals("\t \t \t\\040", JTextBlock.formatLine("\t ".repeat(3)));
+  }
+
+  @Test
+  public void testConstruction() {
+    JTextBlock test = new JTextBlock();
+    test.add("a\n b ");
+    Assert.assertTrue(test.lines().filter(l -> l.equals("a")).findAny().isPresent());
+    Assert.assertTrue(test.lines().filter(l -> l.equals(" b\\040")).findAny().isPresent());
+    Assert.assertEquals(2L, test.lines().count());
+  }
+
+}

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/textblocks/TextBlocks.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/textblocks/TextBlocks.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.helger.jcodemodel.tests.textblocks;
+
+public class TextBlocks {
+    public static final String EMPTY = """
+    """;
+    public static final String ONE_LINE = """
+    a""";
+    public static final String TWO_LINES = """
+    a
+    b""";
+    public static final String TWO_TRIPLEQUOTES_LINES = """
+    \""\"
+    \""\"""";
+    public static final String ONE_LINE_ENDSPACE = """
+    a \040 """;
+    public static final String ONE_LINE_ENDTAB = """
+    a	\011 """;
+    public static final String TWO_LINES_ENDTAB = """
+    a	\011
+    b	\011 """;
+}

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/textblocks/TextBlocksExample.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/textblocks/TextBlocksExample.java
@@ -14,7 +14,7 @@
  */
 package com.helger.jcodemodel.tests.textblocks;
 
-public class TextBlocks {
+public class TextBlocksExample {
     public static final String EMPTY = """
     """;
     public static final String ONE_LINE = """
@@ -22,9 +22,17 @@ public class TextBlocks {
     public static final String TWO_LINES = """
     a
     b""";
-    public static final String TWO_TRIPLEQUOTES_LINES = """
-    \""\"
-    \""\"""";
+    public static final String TWO_DOUBLE_DQUOTES_LINES = """
+    ""
+    "\"""";
+    public static final String TWO_TRIPLE_DQUOTES_LINES = """
+    ""\"
+    ""\"""";
+    public static final String FIVE_DQUOTES = """
+    ""\""\"""";
+    public static final String TWO_FIVE_DQUOTES_LINES = """
+    ""\"""
+    ""\""\"""";
     public static final String ONE_LINE_ENDSPACE = """
     a \040 """;
     public static final String ONE_LINE_ENDTAB = """

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/textblocks/TextBlocksExample.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/textblocks/TextBlocksExample.java
@@ -34,10 +34,10 @@ public class TextBlocksExample {
     ""\"""
     ""\""\"""";
     public static final String ONE_LINE_ENDSPACE = """
-    a \040 """;
+    a  """;
     public static final String ONE_LINE_ENDTAB = """
-    a	\011 """;
+    a		""";
     public static final String TWO_LINES_ENDTAB = """
-    a	\011
-    b	\011 """;
+    a		
+    b		""";
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/textblocks/TextBlocksKeepWhiteSpaces.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/textblocks/TextBlocksKeepWhiteSpaces.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.helger.jcodemodel.tests.textblocks;
+
+public class TextBlocksKeepWhiteSpaces {
+    public static final String ONE_LINE_SPACES = """
+    \040 a \040 """;
+    public static final String ONE_LINE_TABS = """
+    \011a\011 """;
+    public static final String SPACES_EMPTYLINE = """
+     \040
+    """;
+}

--- a/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTestGen.java
+++ b/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTestGen.java
@@ -1,0 +1,31 @@
+package com.helger.jcodemodel.tests.textblocks;
+
+import com.helger.jcodemodel.JDefinedClass;
+import com.helger.jcodemodel.JExpr;
+import com.helger.jcodemodel.JMod;
+import com.helger.jcodemodel.JPackage;
+import com.helger.jcodemodel.compile.annotation.TestJCM;
+import com.helger.jcodemodel.exceptions.JCodeModelException;
+
+@TestJCM
+public class TextBlocksTestGen {
+
+  public void staticBlocks(JPackage root) throws JCodeModelException {
+    JDefinedClass cl = root._class("TextBlocks");
+    cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "EMPTY", JExpr.textBlock());
+    cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "ONE_LINE", JExpr.textBlock().add("a"));
+    cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "TWO_LINES", JExpr.textBlock().add("a\nb"));
+    cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "TWO_TRIPLEQUOTES_LINES",
+        JExpr.textBlock().add("\"\"\"\n\"\"\""));
+    cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "ONE_LINE_ENDSPACE",
+        JExpr.textBlock().add("a  "));
+    cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "ONE_LINE_ENDTAB",
+        JExpr.textBlock().add("a\t\t"));
+    cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "TWO_LINES_ENDTAB",
+        JExpr.textBlock()
+            .add("a\t\t")
+            .add("b\t\t"));
+
+  }
+
+}

--- a/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTestGen.java
+++ b/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTestGen.java
@@ -11,12 +11,22 @@ import com.helger.jcodemodel.exceptions.JCodeModelException;
 public class TextBlocksTestGen {
 
   public void staticBlocks(JPackage root) throws JCodeModelException {
-    JDefinedClass cl = root._class("TextBlocks");
+    JDefinedClass cl = root._class("TextBlocksExample");
     cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "EMPTY", JExpr.textBlock());
     cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "ONE_LINE", JExpr.textBlock().add("a"));
     cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "TWO_LINES", JExpr.textBlock().add("a\nb"));
-    cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "TWO_TRIPLEQUOTES_LINES",
+
+    cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "TWO_DOUBLE_DQUOTES_LINES",
+        JExpr.textBlock().add("\"\"\n\"\""));
+    cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "TWO_TRIPLE_DQUOTES_LINES",
         JExpr.textBlock().add("\"\"\"\n\"\"\""));
+    cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "FIVE_DQUOTES",
+        JExpr.textBlock().add("\"".repeat(5)));
+    cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "TWO_FIVE_DQUOTES_LINES",
+        JExpr.textBlock()
+            .add("\"".repeat(5))
+            .add("\"".repeat(5)));
+
     cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "ONE_LINE_ENDSPACE",
         JExpr.textBlock().add("a  "));
     cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "ONE_LINE_ENDTAB",

--- a/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTestGen.java
+++ b/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTestGen.java
@@ -10,7 +10,7 @@ import com.helger.jcodemodel.exceptions.JCodeModelException;
 @TestJCM
 public class TextBlocksTestGen {
 
-  public void staticBlocks(JPackage root) throws JCodeModelException {
+  public void basicExamples(JPackage root) throws JCodeModelException {
     JDefinedClass cl = root._class("TextBlocksExample");
     cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "EMPTY", JExpr.textBlock());
     cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "ONE_LINE", JExpr.textBlock().add("a"));
@@ -35,6 +35,16 @@ public class TextBlocksTestGen {
         JExpr.textBlock()
             .add("a\t\t")
             .add("b\t\t"));
+  }
+
+  public void keepWhiteSpaces(JPackage root) throws JCodeModelException {
+    JDefinedClass cl = root._class("TextBlocksKeepWhiteSpaces");
+    cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "ONE_LINE_SPACES",
+        JExpr.textBlock().keepWhitespaces(true).add("  a  "));
+    cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "ONE_LINE_TABS",
+        JExpr.textBlock().keepWhitespaces(true).add("	a	"));
+    cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "SPACES_EMPTYLINE",
+        JExpr.textBlock().keepWhitespaces(true).add("  ").newline());
 
   }
 

--- a/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTest.java
+++ b/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTest.java
@@ -7,13 +7,16 @@ public class TextBlocksTest {
 
   @Test
   public void staticBlocks() {
-    Assert.assertEquals("", TextBlocks.EMPTY);
-    Assert.assertEquals("a", TextBlocks.ONE_LINE);
-    Assert.assertEquals("a\nb", TextBlocks.TWO_LINES);
-    Assert.assertEquals("\"\"\"\n\"\"\"", TextBlocks.TWO_TRIPLEQUOTES_LINES);
-    Assert.assertEquals("a  ", TextBlocks.ONE_LINE_ENDSPACE);
-    Assert.assertEquals("a\t\t", TextBlocks.ONE_LINE_ENDTAB);
-    Assert.assertEquals("a\t\t\nb\t\t", TextBlocks.TWO_LINES_ENDTAB);
+    Assert.assertEquals("", TextBlocksExample.EMPTY);
+    Assert.assertEquals("a", TextBlocksExample.ONE_LINE);
+    Assert.assertEquals("a\nb", TextBlocksExample.TWO_LINES);
+    Assert.assertEquals("\"\"\n\"\"", TextBlocksExample.TWO_DOUBLE_DQUOTES_LINES);
+    Assert.assertEquals("\"\"\"\n\"\"\"", TextBlocksExample.TWO_TRIPLE_DQUOTES_LINES);
+    Assert.assertEquals("\"\"\"\"\"", TextBlocksExample.FIVE_DQUOTES);
+    Assert.assertEquals("\"\"\"\"\"\n\"\"\"\"\"", TextBlocksExample.TWO_FIVE_DQUOTES_LINES);
+    Assert.assertEquals("a  ", TextBlocksExample.ONE_LINE_ENDSPACE);
+    Assert.assertEquals("a\t\t", TextBlocksExample.ONE_LINE_ENDTAB);
+    Assert.assertEquals("a\t\t\nb\t\t", TextBlocksExample.TWO_LINES_ENDTAB);
   }
 
 }

--- a/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTest.java
+++ b/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTest.java
@@ -1,0 +1,19 @@
+package com.helger.jcodemodel.tests.textblocks;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TextBlocksTest {
+
+  @Test
+  public void staticBlocks() {
+    Assert.assertEquals("", TextBlocks.EMPTY);
+    Assert.assertEquals("a", TextBlocks.ONE_LINE);
+    Assert.assertEquals("a\nb", TextBlocks.TWO_LINES);
+    Assert.assertEquals("\"\"\"\n\"\"\"", TextBlocks.TWO_TRIPLEQUOTES_LINES);
+    Assert.assertEquals("a  ", TextBlocks.ONE_LINE_ENDSPACE);
+    Assert.assertEquals("a\t\t", TextBlocks.ONE_LINE_ENDTAB);
+    Assert.assertEquals("a\t\t\nb\t\t", TextBlocks.TWO_LINES_ENDTAB);
+  }
+
+}

--- a/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTest.java
+++ b/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 public class TextBlocksTest {
 
   @Test
-  public void staticBlocks() {
+  public void testBasicExamples() {
     Assert.assertEquals("", TextBlocksExample.EMPTY);
     Assert.assertEquals("a", TextBlocksExample.ONE_LINE);
     Assert.assertEquals("a\nb", TextBlocksExample.TWO_LINES);
@@ -14,9 +14,16 @@ public class TextBlocksTest {
     Assert.assertEquals("\"\"\"\n\"\"\"", TextBlocksExample.TWO_TRIPLE_DQUOTES_LINES);
     Assert.assertEquals("\"\"\"\"\"", TextBlocksExample.FIVE_DQUOTES);
     Assert.assertEquals("\"\"\"\"\"\n\"\"\"\"\"", TextBlocksExample.TWO_FIVE_DQUOTES_LINES);
-    Assert.assertEquals("a  ", TextBlocksExample.ONE_LINE_ENDSPACE);
-    Assert.assertEquals("a\t\t", TextBlocksExample.ONE_LINE_ENDTAB);
-    Assert.assertEquals("a\t\t\nb\t\t", TextBlocksExample.TWO_LINES_ENDTAB);
+    Assert.assertEquals("a", TextBlocksExample.ONE_LINE_ENDSPACE);
+    Assert.assertEquals("a", TextBlocksExample.ONE_LINE_ENDTAB);
+    Assert.assertEquals("a\nb", TextBlocksExample.TWO_LINES_ENDTAB);
+  }
+
+  @Test
+  public void testKeepWhiteSpaces() {
+    Assert.assertEquals("  a  ", TextBlocksKeepWhiteSpaces.ONE_LINE_SPACES);
+    Assert.assertEquals("	a	", TextBlocksKeepWhiteSpaces.ONE_LINE_TABS);
+    Assert.assertEquals("  \n", TextBlocksKeepWhiteSpaces.SPACES_EMPTYLINE);
   }
 
 }


### PR DESCRIPTION
Text blocks are multiple text lines used as string.

This PR adds a JTextBlock class, that allows to append lines in a text block , with the following rules

1. newlines are used to split in multiple textblock lines, adding `a\nb` is the same  as adding `a` then `b`
2. triple parenthesis is escape
3. line-ending whitespace or tab is converted to octal whitespace to force keep the trailing whitespaces

What's more, the full text block can be added indentation, with selectable tab/space.
That should work even with single-line or any non-empty terminal line, eg `a\nb` with indent 2 **should** be exported as
```java
"""
  a
  b""".indent(2)
```
