### PR TITLE
minor+doc

### DIFF
--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
@@ -30,8 +30,10 @@ import org.jspecify.annotations.NonNull;
 /// ## Property keepWhiteSpaces
 ///
 /// The produced lines differ depending on [#keepWhitespaces]
-///  - when false(default), the content of the file will be the one added. Adding ` a ` will result in the textblock containing it, thus the resulting line
-///  - when true, the content of the resulting string will be the one added
+///  - when false(default), the content of the file will be the one added.
+///    Adding ` a ` will result in the textblock containing it, thus the resulting line will be `a` because of whitespaces strupping in textblocks
+///  - when true, the content of the resulting string will be the one added.
+///    Adding `  a  ` will result in the textblock containing instead `\040 a \040` to ensure the resulting string will be `  a  `.
 /// In the later, if all lines start with a whitespace, then the first character is set to octal ; plus all line-ending whitespace are also set to octal.
 ///
 /// ## Indentation

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
@@ -10,19 +10,31 @@ import org.jspecify.annotations.NonNull;
 
 /// Represents a text block declaration, one line at a time.
 ///
+/// ## Main usage
 ///
+/// This class produces java text blocks in the generated source file.
+/// It is used by adding lines to it, either one at a time or by passing multiline-string.
+/// The added lines are split by newline separator, then double quotes are escaped when needed.
+/// The [#keepWhiteSpaces] property specifies whether the string added are the one in the *file* (default), or in the resulting *String*.
 ///
-/// ## doublequote escaping
+/// ## Indenting
+///
+/// The [#indentSize] and [#indentChar] (by default size 0 and char space) specify which indentation is to be *added* at the beginning of each line.
+/// Note that if the last line is not empty, then the *source* output will have requested indent but the *produced* String will have space indentation even when [indentChar] is set to tab.
+///
+/// ## Double quote escaping
 ///
 /// triple doublequotes `"""` are escaped by having the third one backslashed `""\"`.
 /// Plus, if the last line ends with an unescaped doublequote, this doublequote is escaped to avoid breaking the parser.
 ///
-/// ## keepWhiteSpaces
+/// ## Property keepWhiteSpaces
 ///
-/// The output of the lines differ depending on [#keepWhitespaces]
-///  - when false(default), the content of the file will be the one added.
+/// The produced lines differ depending on [#keepWhitespaces]
+///  - when false(default), the content of the file will be the one added. Adding ` a ` will result in the textblock containing it, thus the resulting line
 ///  - when true, the content of the resulting string will be the one added
-/// In the later, if all lines start with a whitespace, then all starting whitespace are set to otal ; plus all ending whitespace are also set to octal.
+/// In the later, if all lines start with a whitespace, then the first character is set to octal ; plus all line-ending whitespace are also set to octal.
+///
+/// ## Indentation
 ///
 /// [https://docs.oracle.com/en/java/javase/26/language/text-blocks.html]
 ///
@@ -187,7 +199,7 @@ public class JTextBlock implements IJExpression, Iterable<String> {
       if (!firstLine) {
         f.newline();
       }
-      if (requireEscapeStart) {
+      if (requireEscapeStart && firstLine) {
         // replace starting space/tab by octal
         line =
             line

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/textblocks/TextBlocksKeepWhiteSpaces.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/textblocks/TextBlocksKeepWhiteSpaces.java
@@ -22,4 +22,8 @@ public class TextBlocksKeepWhiteSpaces {
     public static final String SPACES_EMPTYLINE = """
      \040
     """;
+    public static final String THREE_LINES_SPACES = """
+    \040a\040
+     b\040
+     c \040 """;
 }

--- a/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTestGen.java
+++ b/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTestGen.java
@@ -45,6 +45,11 @@ public class TextBlocksTestGen {
         JExpr.textBlock().keepWhitespaces(true).add("	a	"));
     cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "SPACES_EMPTYLINE",
         JExpr.textBlock().keepWhitespaces(true).add("  ").newline());
+    cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "THREE_LINES_SPACES",
+        JExpr.textBlock().keepWhitespaces(true)
+            .add(" a ")
+            .add(" b ")
+            .add(" c  "));
 
   }
 

--- a/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTest.java
+++ b/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTest.java
@@ -24,6 +24,7 @@ public class TextBlocksTest {
     Assert.assertEquals("  a  ", TextBlocksKeepWhiteSpaces.ONE_LINE_SPACES);
     Assert.assertEquals("	a	", TextBlocksKeepWhiteSpaces.ONE_LINE_TABS);
     Assert.assertEquals("  \n", TextBlocksKeepWhiteSpaces.SPACES_EMPTYLINE);
+    Assert.assertEquals(" a \n b \n c  ", TextBlocksKeepWhiteSpaces.THREE_LINES_SPACES);
   }
 
 }


### PR DESCRIPTION
Only first char is escaped when textblock requires to escape whitespaces, added small test