### PR TITLE
add sealed, non-sealed modifiers, and adds permits to JDefinedClass

### DIFF
--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JDefinedClass.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JDefinedClass.java
@@ -41,15 +41,7 @@
 package com.helger.jcodemodel;
 
 import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.stream.Stream;
 
 import org.jspecify.annotations.NonNull;
@@ -95,6 +87,11 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
    * List of interfaces that this class implements
    */
   private final Set <AbstractJClass> m_aInterfaces = new TreeSet <> (ClassNameComparator.getInstance ());
+
+  /**
+   * Set of the classes/interfaces permitted to inherit
+   */
+  private final LinkedHashSet<AbstractJClass> m_aPermited = new LinkedHashSet<>();
 
   /**
    * Fields keyed by their names.
@@ -164,6 +161,7 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
    */
   private final IJGenerifiable m_aGenerifiable = new AbstractJGenerifiableImpl ()
   {
+    @Override
     @NonNull
     public JCodeModel owner ()
     {
@@ -241,10 +239,11 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
       }
     }
 
-    if (isInterface ())
+    if (isInterface ()) {
       m_aMods = JMods.forInterface (nMods);
-    else
+    } else {
       m_aMods = JMods.forClass (nMods);
+    }
   }
 
   /**
@@ -278,8 +277,9 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
     ValueEnforcer.notNull (aSuperClass, "SuperClass");
     if (isInterface ())
     {
-      if (aSuperClass.isInterface ())
+      if (aSuperClass.isInterface ()) {
         return _implements (aSuperClass);
+      }
       throw new IllegalArgumentException ("unable to set the super class for an interface");
     }
 
@@ -312,8 +312,9 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
   @NonNull
   public AbstractJClass _extends ()
   {
-    if (m_aSuperClass == null)
+    if (m_aSuperClass == null) {
       m_aSuperClass = owner ().ref (Object.class);
+    }
     return m_aSuperClass;
   }
 
@@ -345,6 +346,31 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
   public Iterator <AbstractJClass> _implements ()
   {
     return m_aInterfaces.iterator ();
+  }
+
+  /**
+   * This class permits the specified class.
+   *
+   * @param aClass
+   *               class that this class permits
+   * @return This class
+   */
+  @NonNull
+  public JDefinedClass permits(@NonNull final AbstractJClass... aClasses) {
+    if (aClasses != null) {
+      for (@NonNull
+      AbstractJClass ajc : aClasses) {
+        if (ajc instanceof JDefinedClass jdc) {
+          m_aPermited.add(jdc);
+        } else if (ajc instanceof JReferencedClass jrc) {
+          m_aPermited.add(jrc);
+        } else {
+          throw new UnsupportedOperationException("only " + JDefinedClass.class.getSimpleName() + " and "
+              + JReferencedClass.class.getSimpleName() + " can be permitted");
+        }
+      }
+    }
+    return this;
   }
 
   /**
@@ -391,8 +417,9 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
     ValueEnforcer.notNull (aType, "Type");
     ValueEnforcer.notNull (sName, "Name");
 
-    if (!isRecord ())
+    if (!isRecord ()) {
       throw new IllegalStateException ("recordComponent() is only valid for record types");
+    }
 
     final JRecordComponent comp = new JRecordComponent (this, aType, sName, false);
     m_aRecordComponents.add (comp);
@@ -435,8 +462,9 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
     ValueEnforcer.notNull (aType, "Type");
     ValueEnforcer.notNull (sName, "Name");
 
-    if (!isRecord ())
+    if (!isRecord ()) {
       throw new IllegalStateException ("recordComponentVararg() is only valid for record types");
+    }
 
     final JRecordComponent comp = new JRecordComponent (this, aType.array (), sName, true);
     m_aRecordComponents.add (comp);
@@ -470,7 +498,7 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
    * is used for validation or normalization of record components.
    * <p>
    * Example:
-   * 
+   *
    * <pre>
    * public record Range (int lo, int hi)
    * {
@@ -492,11 +520,13 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
   @NonNull
   public JMethod compactConstructor (final int nMods)
   {
-    if (!isRecord ())
+    if (!isRecord ()) {
       throw new IllegalStateException ("compactConstructor() is only valid for record types");
+    }
 
-    if (m_aCompactConstructor != null)
+    if (m_aCompactConstructor != null) {
       throw new IllegalStateException ("Another compact constructor has already been defined");
+    }
 
     m_aCompactConstructor = new JMethod (nMods, this);
     return m_aCompactConstructor;
@@ -515,8 +545,9 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
   @Override
   public String binaryName ()
   {
-    if (getOuter () instanceof AbstractJClassContainer <?>)
+    if (getOuter () instanceof AbstractJClassContainer <?>) {
       return ((AbstractJClassContainer <?>) getOuter ()).binaryName () + '$' + name ();
+    }
 
     // FIXME This is incorrect, e.g. for anonymous classes!
     return fullName ();
@@ -614,8 +645,9 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
    */
   public void removeField (@NonNull final JFieldVar aField)
   {
-    if (m_aFields.remove (aField.name ()) != aField)
+    if (m_aFields.remove (aField.name ()) != aField) {
       throw new IllegalArgumentException ("Failed to remove field " + aField);
+    }
   }
 
   /**
@@ -632,12 +664,13 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
                             @NonNull final String sNewName,
                             @NonNull final JFieldVar aField)
   {
-    if (m_aFields.remove (sOldName) == null)
+    if (m_aFields.remove (sOldName) == null) {
       throw new IllegalArgumentException ("Failed to remove field with name '" +
                                           sOldName +
                                           "' for replacement with field with name '" +
                                           sNewName +
                                           "'");
+    }
     m_aFields.put (sNewName, aField);
   }
 
@@ -649,8 +682,9 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
   @NonNull
   public JBlock init ()
   {
-    if (m_aStaticInit == null)
+    if (m_aStaticInit == null) {
       m_aStaticInit = new JBlock ();
+    }
     return m_aStaticInit;
   }
 
@@ -662,8 +696,9 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
   @NonNull
   public JBlock instanceInit ()
   {
-    if (m_aInstanceInit == null)
+    if (m_aInstanceInit == null) {
       m_aInstanceInit = new JBlock ();
+    }
     return m_aInstanceInit;
   }
 
@@ -709,9 +744,11 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
   @Nullable
   public JMethod getConstructor (@NonNull final AbstractJType [] aArgTypes)
   {
-    for (final JMethod m : m_aConstructors)
-      if (m.hasSignature (aArgTypes))
+    for (final JMethod m : m_aConstructors) {
+      if (m.hasSignature (aArgTypes)) {
         return m;
+      }
+    }
     return null;
   }
 
@@ -762,10 +799,13 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
   @Nullable
   public JMethod getMethod (final String sName, final AbstractJType [] aArgTypes)
   {
-    for (final JMethod m : m_aMethods)
-      if (m.name ().equals (sName))
-        if (m.hasSignature (aArgTypes))
+    for (final JMethod m : m_aMethods) {
+      if (m.name ().equals (sName)) {
+        if (m.hasSignature (aArgTypes)) {
           return m;
+        }
+      }
+    }
     return null;
   }
 
@@ -785,16 +825,19 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
   @NonNull
   public JDocComment headerComment ()
   {
-    if (m_aHeaderComment == null)
+    if (m_aHeaderComment == null) {
       m_aHeaderComment = new JDocComment (owner ());
+    }
     return m_aHeaderComment;
   }
 
+  @Override
   @NonNull
   public JDocComment javadoc ()
   {
-    if (m_aJDoc == null)
+    if (m_aJDoc == null) {
       m_aJDoc = new JDocComment (owner ());
+    }
     return m_aJDoc;
   }
 
@@ -813,16 +856,20 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
     return m_bHideFile;
   }
 
+  @Override
   public void declare (@NonNull final IJFormatter f)
   {
     // Java docs
-    if (m_aJDoc != null)
+    if (m_aJDoc != null) {
       f.newline ().generable (m_aJDoc);
+    }
 
     // Class annotations
-    if (m_aAnnotations != null)
-      for (final JAnnotationUse aAnnotation : m_aAnnotations)
+    if (m_aAnnotations != null) {
+      for (final JAnnotationUse aAnnotation : m_aAnnotations) {
         f.generable (aAnnotation).newline ();
+      }
+    }
 
     // Modifiers (private, protected, public)
     // Type of class (class, interface, enum, @interface, record)
@@ -837,10 +884,11 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
       boolean bFirst = true;
       for (final JRecordComponent comp : m_aRecordComponents)
       {
-        if (bFirst)
+        if (bFirst) {
           bFirst = false;
-        else
+        } else {
           f.print (',');
+        }
         f.generable (comp);
       }
       f.print (')');
@@ -858,11 +906,24 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
     // Add all interfaces
     if (!m_aInterfaces.isEmpty ())
     {
-      if (!bHasSuperClass)
+      if (!bHasSuperClass) {
         f.newline ();
+      }
       f.indent ().print (isInterface () ? "extends" : "implements");
       f.generable (m_aInterfaces);
       f.newline ().outdent ();
+    }
+
+    if (!m_aPermited.isEmpty()) {
+      f.print("permits");
+      boolean first = true;
+      for (AbstractJClass ajc : m_aPermited) {
+        if (!first) {
+          f.print(',');
+        }
+        ajc.erasure().generate(f);
+        first = false;
+      }
     }
 
     declareBody (f);
@@ -883,37 +944,43 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
     {
       for (final JEnumConstant c : m_aEnumConstantsByName.values ())
       {
-        if (bFirst)
+        if (bFirst) {
           bFirst = false;
-        else
+        } else {
           f.print (',').newline ();
+        }
         f.declaration (c);
       }
       f.print (';').newline ();
     }
 
     // All fields
-    for (final JFieldVar field : m_aFields.values ())
+    for (final JFieldVar field : m_aFields.values ()) {
       f.declaration (field);
+    }
 
     // Static init
-    if (m_aStaticInit != null)
+    if (m_aStaticInit != null) {
       f.newline ().print ("static").statement (m_aStaticInit);
+    }
 
     // Instance init
-    if (m_aInstanceInit != null)
+    if (m_aInstanceInit != null) {
       f.newline ().statement (m_aInstanceInit);
+    }
 
     // Compact constructor for records (special syntax without parameter list)
     if (m_aCompactConstructor != null)
     {
       f.newline ();
       // Output javadoc if present
-      if (m_aCompactConstructor.hasJavadoc ())
+      if (m_aCompactConstructor.hasJavadoc ()) {
         f.generable (m_aCompactConstructor.javadoc ());
+      }
       // Output annotations
-      for (final JAnnotationUse annotation : m_aCompactConstructor.annotations ())
+      for (final JAnnotationUse annotation : m_aCompactConstructor.annotations ()) {
         f.generable (annotation).newline ();
+      }
       // Output modifiers and name only (no parentheses)
       f.generable (m_aCompactConstructor.mods ()).id (name ());
       // Output body
@@ -921,21 +988,26 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
     }
 
     // All regular constructors
-    for (final JMethod m : m_aConstructors)
+    for (final JMethod m : m_aConstructors) {
       f.newline ().declaration (m);
+    }
 
     // All regular methods
-    for (final JMethod m : m_aMethods)
+    for (final JMethod m : m_aMethods) {
       f.newline ().declaration (m);
+    }
 
     // All inner classes
-    if (m_aClasses != null)
-      for (final JDefinedClass dc : m_aClasses.values ())
+    if (m_aClasses != null) {
+      for (final JDefinedClass dc : m_aClasses.values ()) {
         f.newline ().declaration (dc);
+      }
+    }
 
     // Hacks...
-    if (m_sDirectBlock != null)
+    if (m_sDirectBlock != null) {
       f.print (m_sDirectBlock);
+    }
 
     f.outdent ().print ('}').newline ();
   }
@@ -950,11 +1022,12 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
    */
   public void direct (@Nullable final String string)
   {
-    if (m_sDirectBlock == null)
+    if (m_sDirectBlock == null) {
       m_sDirectBlock = string;
-    else
-      if (string != null)
+    } else
+      if (string != null) {
         m_sDirectBlock += string;
+      }
   }
 
   @Override
@@ -962,23 +1035,27 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
   public final JPackage _package ()
   {
     IJClassContainer <?> p = getOuter ();
-    while (!(p instanceof JPackage))
+    while (!(p instanceof JPackage)) {
       p = p.parentContainer ();
+    }
     return (JPackage) p;
   }
 
+  @Override
   @NonNull
   public JTypeVar generify (@NonNull final String sName)
   {
     return m_aGenerifiable.generify (sName);
   }
 
+  @Override
   @NonNull
   public JTypeVar generify (@NonNull final String sName, @NonNull final Class <?> aBoundClass)
   {
     return m_aGenerifiable.generify (sName, aBoundClass);
   }
 
+  @Override
   @NonNull
   public JTypeVar generify (@NonNull final String sName, @NonNull final AbstractJClass aBoundClass)
   {
@@ -999,17 +1076,20 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
     return this;
   }
 
+  @Override
   @NonNull
   public JAnnotationUse annotate (@NonNull final Class <? extends Annotation> aClazz)
   {
     return annotate (owner ().ref (aClazz));
   }
 
+  @Override
   @NonNull
   public JAnnotationUse annotate (@NonNull final AbstractJClass aClazz)
   {
-    if (m_aAnnotations == null)
+    if (m_aAnnotations == null) {
       m_aAnnotations = new ArrayList <> ();
+    }
     final JAnnotationUse a = new JAnnotationUse (aClazz);
     m_aAnnotations.add (a);
     return a;
@@ -1018,11 +1098,13 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
   @NonNull
   public List <JAnnotationUse> annotationsMutable ()
   {
-    if (m_aAnnotations == null)
+    if (m_aAnnotations == null) {
       m_aAnnotations = new ArrayList <> ();
+    }
     return m_aAnnotations;
   }
 
+  @Override
   @NonNull
   public Collection <JAnnotationUse> annotations ()
   {
@@ -1032,7 +1114,7 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
   @Nullable
   public JAnnotationUse getAnnotation (final Class <?> aAnnotationClass)
   {
-    if (m_aAnnotations != null)
+    if (m_aAnnotations != null) {
       for (final JAnnotationUse jannotation : m_aAnnotations)
       {
         final AbstractJClass jannotationClass = jannotation.getAnnotationClass ();
@@ -1045,6 +1127,7 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
           }
         }
       }
+    }
     return null;
   }
 

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JMod.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JMod.java
@@ -62,6 +62,8 @@ public final class JMod
   /** Java8 default method indicator */
   public static final int DEFAULT = 0x400;
   public static final int STRICTFP = 0x800;
+  public static final int SEALED = 0x1000;
+  public static final int NONSEALED = 0x2000;
 
   public static final int PRIVATE_FINAL = PRIVATE | FINAL;
   public static final int PUBLIC_STATIC_FINAL = PUBLIC | STATIC | FINAL;

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JMods.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JMods.java
@@ -40,11 +40,10 @@
  */
 package com.helger.jcodemodel;
 
-import java.lang.reflect.Modifier;
-
 import org.jspecify.annotations.NonNull;
 
 import com.helger.base.enforce.ValueEnforcer;
+import com.helger.jcodemodel.modifiers.EMod;
 
 /**
  * Modifier groups.
@@ -76,8 +75,14 @@ public class JMods implements IJGenerable
                                    JMod.PROTECTED |
                                    JMod.STATIC |
                                    JMod.FINAL |
-                                   JMod.ABSTRACT;
-  private static final int INTERFACE = JMod.PUBLIC | JMod.PRIVATE | JMod.PROTECTED;
+                                   JMod.ABSTRACT |
+                                   JMod.SEALED |
+                                   JMod.NONSEALED ;
+  private static final int INTERFACE = JMod.PUBLIC |
+                      JMod.PRIVATE |
+                      JMod.PROTECTED |
+                      JMod.SEALED |
+                      JMod.NONSEALED;
 
   /** bit-packed representation of modifiers. */
   private int m_nMods;
@@ -146,6 +151,16 @@ public class JMods implements IJGenerable
   {
     return (m_nMods & JMod.FINAL) != 0;
   }
+
+  public boolean isSealed ()
+  {
+    return (m_nMods & JMod.SEALED) != 0;
+  }
+
+  public boolean isNonSealed ()
+  {
+    return (m_nMods & JMod.NONSEALED) != 0;
+  }	
 
   public boolean isNative ()
   {
@@ -253,6 +268,16 @@ public class JMods implements IJGenerable
     _setFlag (JMod.FINAL, bNewValue);
   }
 
+  public void setSealed (final boolean bNewValue)
+  {
+    _setFlag (JMod.SEALED, bNewValue);
+  }
+
+  public void setNonSealed (final boolean bNewValue)
+  {
+    _setFlag (JMod.NONSEALED, bNewValue);
+  }
+
   @Override
   public void generate (@NonNull final IJFormatter f)
   {
@@ -275,6 +300,12 @@ public class JMods implements IJGenerable
     if ((m_nMods & JMod.FINAL) != 0)
       f.print ("final");
 
+    if ((m_nMods & JMod.SEALED) != 0)
+      f.print ("sealed");
+
+    if ((m_nMods & JMod.NONSEALED) != 0)
+      f.print ("non-sealed");
+
     if ((m_nMods & JMod.TRANSIENT) != 0)
       f.print ("transient");
 
@@ -294,50 +325,10 @@ public class JMods implements IJGenerable
       f.print ("default");
   }
 
-  public enum ModifierMap
-  {
-    NONE (JMod.NONE, 0),
-    PUBLIC (JMod.PUBLIC, Modifier.PUBLIC),
-    PROTECTED (JMod.PROTECTED, Modifier.PROTECTED),
-    PRIVATE (JMod.PRIVATE, Modifier.PRIVATE),
-    FINAL (JMod.FINAL, Modifier.FINAL),
-    STATIC (JMod.STATIC, Modifier.STATIC),
-    ABSTRACT (JMod.ABSTRACT, Modifier.ABSTRACT),
-    NATIVE (JMod.NATIVE, Modifier.NATIVE),
-    SYNCHRONIZED (JMod.SYNCHRONIZED, Modifier.SYNCHRONIZED),
-    TRANSIENT (JMod.TRANSIENT, Modifier.TRANSIENT),
-    VOLATILE (JMod.VOLATILE, Modifier.VOLATILE),
-    /*
-     * default does not exist in the reflect : it's a public non-abstrct non-static method in an
-     * interface
-     */
-    DEFAULT (JMod.DEFAULT, 0),
-    STRICTFP (JMod.STRICTFP, Modifier.STRICT);
-
-    public final int m_nJMod;
-    public final int m_nModifier;
-
-    ModifierMap (final int jmod, final int modifier)
-    {
-      m_nJMod = jmod;
-      m_nModifier = modifier;
-    }
-
-    public boolean isPresentJMod (final int jmods)
-    {
-      return (m_nJMod & jmods) != 0;
-    }
-
-    public boolean isPresentModifiers (final int modifiers)
-    {
-      return m_nModifier != 0 && (m_nModifier & modifiers) != 0;
-    }
-  }
-
   public static int toModifier (final int jmod)
   {
     int ret = 0;
-    for (final ModifierMap e : ModifierMap.values ())
+    for (final EMod e : EMod.values ())
     {
       if (e.isPresentJMod (jmod))
         ret |= e.m_nModifier;
@@ -348,7 +339,7 @@ public class JMods implements IJGenerable
   public static int fromModifier (final int modifier)
   {
     int ret = 0;
-    for (final ModifierMap e : ModifierMap.values ())
+    for (final EMod e : EMod.values ())
     {
       if (e.isPresentModifiers (modifier))
         ret |= e.m_nJMod;

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/modifiers/EMod.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/modifiers/EMod.java
@@ -1,0 +1,215 @@
+package com.helger.jcodemodel.modifiers;
+
+import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.helger.jcodemodel.AbstractJClass;
+import com.helger.jcodemodel.JAnnotatedClass;
+import com.helger.jcodemodel.JDefinedClass;
+import com.helger.jcodemodel.JMod;
+import com.helger.jcodemodel.JNarrowedClass;
+import com.helger.jcodemodel.JReferencedClass;
+
+/// Modifiers applied to declared/defined elements, ordered by name ascending.
+///
+/// The JMod part refers to the [JMod] int enumeration.
+/// The modifier field refers to the enum value in the reflect api [Modifier], if avail. 0 if not, consistent with bitwise operations.
+///
+///
+/// This class should replace JMod in the long term, but they both should coexist for now.
+/// Intermediate step will be, to use this class internally by mapping the JMod to it.
+///
+public enum EMod
+{
+  ABSTRACT(JMod.ABSTRACT, Modifier.ABSTRACT, "abstract"),
+  /// default does not exist in reflect : it's a public non-abstrct non-static
+  /// method in an interface
+  DEFAULT(JMod.DEFAULT, 0, "default"),
+  FINAL(JMod.FINAL, Modifier.FINAL, "final"),
+  NATIVE(JMod.NATIVE, Modifier.NATIVE, "native"),
+  NONE(JMod.NONE, 0, ""),
+  /// nopn-sealed is not present at runtime, indicates allowed inheritance
+  NONSEALED(JMod.NONSEALED, 0, "non-sealed"),
+  PRIVATE(JMod.PRIVATE, Modifier.PRIVATE, "private"),
+  PROTECTED(JMod.PROTECTED, Modifier.PROTECTED, "protected"),
+  PUBLIC(JMod.PUBLIC, Modifier.PUBLIC, "public"),
+  /// sealed is not present at runtime, indicates allowed inheritance
+  SEALED(JMod.SEALED, 0, "sealed"),
+  STATIC(JMod.STATIC, Modifier.STATIC, "static"),
+  STRICTFP(JMod.STRICTFP, Modifier.STRICT, "strictftp"),
+  SYNCHRONIZED(JMod.SYNCHRONIZED, Modifier.SYNCHRONIZED, "synchronized"),
+  TRANSIENT(JMod.TRANSIENT, Modifier.TRANSIENT, "transient"),
+  VOLATILE(JMod.VOLATILE, Modifier.VOLATILE, "volatile");
+
+  public final int m_nJMod;
+  public final int m_nModifier;
+  public final String m_sFormat;
+
+  /// since we can't generate the list in the constructor, this is the same as
+  /// field per enum.
+  private static final Map<EMod, Set<EMod>> EXCLUDES_CACHE = new HashMap<>();
+
+  // cached map of JMod -> Emod
+  private static final Map<Integer, EMod> JMOD_CACHE =
+      Stream.of(values()).collect(Collectors.toMap(em -> em.m_nJMod, em -> em));
+
+  /// modifiers allowed on a class definition
+  public static final Set<EMod> ALLOWED_CLASS =
+      Collections.unmodifiableSet(EnumSet.of(
+          ABSTRACT,
+          FINAL,
+          NONSEALED,
+          PUBLIC,
+          PRIVATE,
+          PROTECTED,
+          SEALED,
+          STATIC
+      ));
+
+  /// modifiers allowed on a field declaration
+  public static final Set<EMod> ALLOWED_FIELD =
+      Collections.unmodifiableSet(EnumSet.of(
+          FINAL,
+          PUBLIC,
+          PRIVATE,
+          PROTECTED,
+          STATIC,
+          TRANSIENT,
+          VOLATILE));
+
+  /// modifiers allowed on an interface definition
+  public static final Set<EMod> ALLOWED_INTERFACE =
+      Collections.unmodifiableSet(EnumSet.of(
+          NONSEALED,
+          PUBLIC,
+          PRIVATE,
+          PROTECTED,
+          SEALED
+      ));
+
+  /// modifiers allowed on a method declaration
+  public static final Set<EMod> ALLOWED_METHOD =
+      Collections.unmodifiableSet(EnumSet.of(
+          ABSTRACT,
+          DEFAULT,
+          FINAL,
+          NATIVE,
+          PUBLIC,
+          PRIVATE,
+          PROTECTED,
+          STATIC,
+          SYNCHRONIZED
+      ));
+
+  /// modifiers allowed on a variable declaration
+  public static final Set<EMod> ALLOWED_VAR =
+      Collections.unmodifiableSet(EnumSet.of(
+          FINAL
+      ));
+
+  /// list of the modifiers that are mutually exclusive
+  public static final List<Set<EMod>> MUTUAL_EXCLUSIONS =
+      List.of(
+          Collections.unmodifiableSet(EnumSet.of(
+              PUBLIC,
+              PRIVATE,
+              PROTECTED)),
+          Collections.unmodifiableSet(EnumSet.of(
+              NONSEALED,
+              SEALED))
+      );
+
+  EMod(final int jmod, final int modifier, String format)
+  {
+    m_nJMod = jmod;
+    m_nModifier = modifier;
+    m_sFormat = format;
+  }
+
+  //
+  // tooling
+  //
+
+  /// find the corresponding value for given JMod int value.
+  /// @return null if none matches.
+  public static EMod ofJMod(int jmodValue) {
+    return JMOD_CACHE.get(jmodValue);
+  }
+
+  /// find the list of elements present in a JMods int value
+  /// @return a new, possibly empty, modifiable enum set.
+  public static EnumSet<EMod> ofJMods(int jmodValue) {
+    EnumSet<EMod> ret = EnumSet.noneOf(EMod.class);
+    for (EMod em : values()) {
+      if (em.isPresentJMod(jmodValue)) {
+        ret.add(em);
+      }
+    }
+    return ret;
+  }
+
+  /// transforms a set, typically an enumset, into a JMod bits-int.
+  public static int toJMod(Set<EMod> set) {
+    return set.stream()
+        .map(em -> em.m_nJMod)
+        .collect(Collectors
+            .reducing(0, (l, r) -> l | r));
+  }
+
+  /// the list of modifiers this one excludes.
+  public Set<EMod> excludes() {
+    Set<EMod> ret = EXCLUDES_CACHE.get(this);
+    if (ret == null) {
+      synchronized (EXCLUDES_CACHE) {
+        ret =
+            EXCLUDES_CACHE.computeIfAbsent(this,
+                e -> MUTUAL_EXCLUSIONS.stream()
+                    .filter(s -> s.contains(e))
+                    .flatMap(Set::stream)
+                    .filter(e2 -> e2 != e)
+                    .collect(Collectors.toCollection(() -> EnumSet.noneOf(EMod.class))));
+      }
+    }
+    return ret;
+  }
+
+  public boolean isPresentJMod (final int jmods)
+  {
+    return (m_nJMod & jmods) != 0;
+  }
+
+  public int addJMod(final int jmods) {
+    return jmods | m_nJMod;
+  }
+
+  public boolean isPresentModifiers (final int modifiers)
+  {
+    return m_nModifier != 0 && (m_nModifier & modifiers) != 0;
+  }
+
+  /// test whether this mod is present. The [AbstractJClass] is tested as instance
+  /// of defined, referenced, annotated, narrowed class.
+  ///
+  /// Otherwise returns false.
+  public boolean isPresent(AbstractJClass ajc)
+  {
+    if (ajc instanceof JDefinedClass jdc) {
+      return isPresentJMod(jdc.mods().getValue());
+    } else if (ajc instanceof JReferencedClass jrc) {
+      return isPresentModifiers(jrc.getReferencedClass().getModifiers());
+    } else if( ajc instanceof JAnnotatedClass jac) {
+      return isPresent(jac.basis());
+    } else if (ajc instanceof JNarrowedClass jnc) {
+      return isPresent(jnc.basis());
+    }
+    return false;
+  }
+
+}

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/sealed/ImplFinal.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/sealed/ImplFinal.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.helger.jcodemodel.tests.sealed;
+
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
+public final class ImplFinal
+    implements SealedInterface
+{
+}

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/sealed/ImplNonsealed.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/sealed/ImplNonsealed.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.helger.jcodemodel.tests.sealed;
+
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
+public non-sealed class ImplNonsealed
+    implements SealedInterface
+{
+}

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/sealed/ImplSealed.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/sealed/ImplSealed.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.helger.jcodemodel.tests.sealed;
+
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
+public sealed class ImplSealed
+    implements SealedInterface
+permits ImplSealedChildNonsealed, ImplSealedChildFinal {
+}

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/sealed/ImplSealedChildFinal.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/sealed/ImplSealedChildFinal.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.helger.jcodemodel.tests.sealed;
+
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
+public final class ImplSealedChildFinal
+    extends ImplSealed
+{
+}

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/sealed/ImplSealedChildNonsealed.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/sealed/ImplSealedChildNonsealed.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.helger.jcodemodel.tests.sealed;
+
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
+public non-sealed class ImplSealedChildNonsealed
+    extends ImplSealed
+{
+}

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/sealed/SealedInterface.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/sealed/SealedInterface.java
@@ -1,0 +1,21 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * 				http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.helger.jcodemodel.tests.sealed;
+
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
+public sealed interface SealedInterface permits ImplFinal, ImplSealed, ImplNonsealed {
+}

--- a/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/sealed/SealedTestGen.java
+++ b/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/sealed/SealedTestGen.java
@@ -1,0 +1,29 @@
+package com.helger.jcodemodel.tests.sealed;
+
+import org.jspecify.annotations.NonNull;
+
+import com.helger.jcodemodel.JDefinedClass;
+import com.helger.jcodemodel.JMod;
+import com.helger.jcodemodel.JPackage;
+import com.helger.jcodemodel.compile.annotation.TestJCM;
+import com.helger.jcodemodel.exceptions.JCodeModelException;
+
+@TestJCM
+public class SealedTestGen {
+
+  public void basicExample(JPackage root) throws JCodeModelException {
+    @NonNull
+    JDefinedClass itf = root._interface("SealedInterface");
+    itf.mods().setSealed(true);
+    JDefinedClass implFinal = root._class(JMod.PUBLIC | JMod.FINAL, "ImplFinal")._implements(itf);
+    JDefinedClass implSealed = root._class(JMod.PUBLIC | JMod.SEALED, "ImplSealed")._implements(itf);
+    JDefinedClass implNonsealed = root._class(JMod.PUBLIC | JMod.NONSEALED, "ImplNonsealed")._implements(itf);
+    itf.permits(implFinal, implSealed, implNonsealed);
+    JDefinedClass implSealedChildNonSealed =
+        root._class(JMod.PUBLIC | JMod.NONSEALED, "ImplSealedChildNonsealed")._extends(implSealed);
+    JDefinedClass implSealedChildFinal =
+        root._class(JMod.PUBLIC | JMod.FINAL, "ImplSealedChildFinal")._extends(implSealed);
+    implSealed.permits(implSealedChildNonSealed, implSealedChildFinal);
+  }
+
+}

--- a/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/sealed/SealedTest.java
+++ b/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/sealed/SealedTest.java
@@ -1,0 +1,18 @@
+package com.helger.jcodemodel.tests.sealed;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SealedTest {
+
+  @Test
+  public void testBasicExample() {
+    Assert.assertTrue(SealedInterface.class.isSealed());
+    Assert.assertFalse(ImplFinal.class.isSealed());
+    Assert.assertFalse(ImplNonsealed.class.isSealed());
+    Assert.assertTrue(ImplSealed.class.isSealed());
+    Assert.assertFalse(ImplSealedChildFinal.class.isSealed());
+    Assert.assertFalse(ImplSealedChildNonsealed.class.isSealed());
+  }
+
+}


### PR DESCRIPTION
An additional modification is in the EMod class that contains a true enum of the JMod, moved from the previous class. It's not used (yet), but can provide more integration especially by knowing which modifiers are mutually exclusive