### PR TITLE
Textblock fixes

### DIFF
--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
@@ -204,7 +204,7 @@ public class JTextBlock implements IJExpression, Iterable<String> {
         // replace starting space/tab by octal
         line =
             line
-                .replaceAll("^ ", "\\\\040")
+                .replaceAll("^ ", "\\\\s")
                 .replaceAll("^\t", "\\\\011");
         escapeFirstChar = false;
       }
@@ -212,7 +212,7 @@ public class JTextBlock implements IJExpression, Iterable<String> {
         // replace ending space/tab by octal
         line =
             line
-                .replaceAll(" $", "\\\\040")
+                .replaceAll(" $", "\\\\s")
                 .replaceAll("\t$", "\\\\011");
       }
       f.print(indent).print(line);

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JTextBlock.java
@@ -30,15 +30,15 @@ import org.jspecify.annotations.NonNull;
 /// ## Property keepWhiteSpaces
 ///
 /// The produced lines differ depending on [#keepWhitespaces]
-///  - when false(default), the content of the file will be the one added.
+///  - when false(default), the content of the **file** will be the one added.
 ///    Adding ` a ` will result in the textblock containing it, thus the resulting line will be `a` because of whitespaces strupping in textblocks
-///  - when true, the content of the resulting string will be the one added.
-///    Adding `  a  ` will result in the textblock containing instead `\040 a \040` to ensure the resulting string will be `  a  `.
+///  - when true, the content of the **parsed string** will be the one added.
+///    Adding `  a  ` will result in the textblock containing instead `\040 a \040` to ensure the parsed string will be `  a  `.
 /// In the later, if all lines start with a whitespace, then the first character is set to octal ; plus all line-ending whitespace are also set to octal.
 ///
-/// ## Indentation
 ///
 /// [https://docs.oracle.com/en/java/javase/26/language/text-blocks.html]
+/// @author Guillaume Le Louët (guillaume.lelouet@gmail.com)
 ///
 @SuppressWarnings("serial")
 public class JTextBlock implements IJExpression, Iterable<String> {
@@ -190,23 +190,23 @@ public class JTextBlock implements IJExpression, Iterable<String> {
         modifiedLines.set(modifiedLines.size() - 1, escapedLastLine);
       }
     }
-    // we need to escape starting whitespaces iff we are verbatim and all lines
-    // start with space or tab
-    boolean requireEscapeStart =
-        keepWhitespaces
-            && modifiedLines.stream()
-                .filter(l -> !l.startsWith(" ") && !l.startsWith("\t"))
-                .findAny().isEmpty();
+
+    boolean escapeFirstChar = requiresEscapeFirstChar(keepWhitespaces, modifiedLines);
+//		if (keepWhitespaces) {
+//			System.err.println("escapefirst " + escapeFirstChar + " from " + modifiedLines);
+//		}
+
     for (String line : modifiedLines) {
       if (!firstLine) {
         f.newline();
       }
-      if (requireEscapeStart && firstLine) {
+      if (escapeFirstChar && !line.isEmpty()) {
         // replace starting space/tab by octal
         line =
             line
                 .replaceAll("^ ", "\\\\040")
                 .replaceAll("^\t", "\\\\011");
+        escapeFirstChar = false;
       }
       if (keepWhitespaces) {
         // replace ending space/tab by octal
@@ -228,6 +228,23 @@ public class JTextBlock implements IJExpression, Iterable<String> {
           .print("" + indentSize)
           .print(")");
     }
+  }
+
+  /// We need to escape initial whitespace to preserve indentation iff
+  /// 1. we are keepWhitespaces
+  /// 2. there are lines
+  /// 3. all non-blank line start with space/tab
+  /// 4. final line starts with space/tab even if blank
+  static boolean requiresEscapeFirstChar(boolean keepWhitespaces, List<String> lines) {
+    return keepWhitespaces
+        && !lines.isEmpty()
+        // no non-blank line that does not start with a space or tab
+        && lines.stream()
+            .filter(l -> !(l.isBlank() || l.startsWith(" ") || l.startsWith("\t")))
+            .findAny().isEmpty()
+        // if last line does not start with space/tab we don't need to escape, blank or
+        // not.
+        && lines.get(lines.size() - 1).matches("^[ \\t].*");
   }
 
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/textblocks/TextBlocksKeepWhiteSpaces.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/textblocks/TextBlocksKeepWhiteSpaces.java
@@ -29,4 +29,12 @@ public class TextBlocksKeepWhiteSpaces {
     \040a\040
      b\040
      c \040 """;
+    public static final String EMPTY_THEN_SPACED = """
+
+    \040 a""";
+    public static final String TWO_EMPTY_LINES_2SPACES_3SPACES = """
+
+
+    \040\040
+      \040 """;
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/textblocks/TextBlocksKeepWhiteSpaces.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/textblocks/TextBlocksKeepWhiteSpaces.java
@@ -19,22 +19,22 @@ import javax.annotation.processing.Generated;
 @Generated("com.helger.jcodemodel.JCodeModel")
 public class TextBlocksKeepWhiteSpaces {
     public static final String ONE_LINE_SPACES = """
-    \040 a \040 """;
+    \s a \s""";
     public static final String ONE_LINE_TABS = """
     \011a\011 """;
     public static final String SPACES_EMPTYLINE = """
-     \040
+     \s
     """;
     public static final String THREE_LINES_SPACES = """
-    \040a\040
-     b\040
-     c \040 """;
+    \sa\s
+     b\s
+     c \s""";
     public static final String EMPTY_THEN_SPACED = """
 
-    \040 a""";
+    \s a""";
     public static final String TWO_EMPTY_LINES_2SPACES_3SPACES = """
 
 
-    \040\040
-      \040 """;
+    \s\s
+      \s""";
 }

--- a/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTestGen.java
+++ b/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTestGen.java
@@ -50,6 +50,16 @@ public class TextBlocksTestGen {
             .add(" a ")
             .add(" b ")
             .add(" c  "));
+    cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "EMPTY_THEN_SPACED",
+        JExpr.textBlock().keepWhitespaces(true)
+            .newline()
+            .add("  a"));
+    cl.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, String.class, "TWO_EMPTY_LINES_2SPACES_3SPACES",
+        JExpr.textBlock().keepWhitespaces(true)
+            .newline()
+            .newline()
+            .add("  ")
+            .add("   "));
 
   }
 

--- a/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTest.java
+++ b/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/textblocks/TextBlocksTest.java
@@ -25,6 +25,8 @@ public class TextBlocksTest {
     Assert.assertEquals("	a	", TextBlocksKeepWhiteSpaces.ONE_LINE_TABS);
     Assert.assertEquals("  \n", TextBlocksKeepWhiteSpaces.SPACES_EMPTYLINE);
     Assert.assertEquals(" a \n b \n c  ", TextBlocksKeepWhiteSpaces.THREE_LINES_SPACES);
+    Assert.assertEquals("\n  a", TextBlocksKeepWhiteSpaces.EMPTY_THEN_SPACED);
+    Assert.assertEquals("\n\n  \n   ", TextBlocksKeepWhiteSpaces.TWO_EMPTY_LINES_2SPACES_3SPACES);
   }
 
 }


### PR DESCRIPTION
Fixes  intermediate blank (typically empty) line still counting for escaping the first char (when keepwhitespaces)
Typically exporting `\n  a` was producing `\na`

Replaces the octal escape for space `\040` with `\s` for nicer visual