### PR TITLE
Lazy init pattern

### DIFF
--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JDefinedClass.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JDefinedClass.java
@@ -122,6 +122,11 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
    * Set of methods that are members of this class
    */
   private final List <JMethod> m_aMethods = new ArrayList <> ();
+  
+  /**
+   * set of the extra declarations. Those are kept in the order of addition, removing duplicates, and are added at the end of the body declaration. 
+   */
+  private final LinkedHashSet<IJDeclaration> m_sExtraDeclarations = new LinkedHashSet<>();
 
   /**
    * Flag that controls whether this class should be really generated or not. Sometimes it is useful
@@ -779,7 +784,7 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
   }
 
   /**
-   * @return the set of methods defined in this class.
+   * @return the methods defined in this class.
    */
   @NonNull
   public Collection <JMethod> methods ()
@@ -807,6 +812,11 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
       }
     }
     return null;
+  }
+  
+  public LinkedHashSet<IJDeclaration> getExtraDeclarations()
+  {
+    return m_sExtraDeclarations;
   }
 
   /**
@@ -1007,6 +1017,11 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
     // Hacks...
     if (m_sDirectBlock != null) {
       f.print (m_sDirectBlock);
+    }
+
+    // extra declarations
+    for (final IJDeclaration ijd : m_sExtraDeclarations) {
+      f.newline ().declaration (ijd);
     }
 
     f.outdent ().print ('}').newline ();

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JFieldVar.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JFieldVar.java
@@ -74,7 +74,7 @@ public class JFieldVar extends JVar implements IJDocCommentable
    * @param aInit
    *        Value to initialize this variable to
    */
-  protected JFieldVar (@NonNull final JDefinedClass aOwnerClass,
+  public JFieldVar (@NonNull final JDefinedClass aOwnerClass,
                        @NonNull final JMods aMods,
                        @NonNull final AbstractJType aType,
                        @NonNull final String sName,

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JMethod.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JMethod.java
@@ -125,7 +125,7 @@ public class JMethod extends AbstractJGenerifiableImpl implements IJAnnotatable,
    * @param sName
    *        Name of this method. May neither be <code>null</code> nor empty.
    */
-  protected JMethod (@NonNull final JDefinedClass aOwningClass,
+  public JMethod (@NonNull final JDefinedClass aOwningClass,
                      final int nMods,
                      @NonNull final AbstractJType aReturnType,
                      @NonNull final String sName)

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/patterns/JLazy.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/patterns/JLazy.java
@@ -6,15 +6,15 @@ import com.helger.base.enforce.ValueEnforcer;
 import com.helger.jcodemodel.*;
 
 
-/// Create an expression to initialize at most once a value from another
-/// expression.
+/// Create an expression initialized at most once from another expression.
 ///
 /// For example, you want `getString()` to cache the result of the method `String
-/// longMethod() ` :
+/// longMethod() ` , then check that thjs value if ≥ 5:
 /// ```java
 /// var lazy = new JLazy(myJDefinedClass, String.class, "getString")
 ///    .static()
 ///    .init(Jexpr.invoke("longMethod"));
+/// lazy.expr().ge(5);
 ///
 /// ```
 ///

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/patterns/JLazy.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/patterns/JLazy.java
@@ -1,0 +1,176 @@
+package com.helger.jcodemodel.patterns;
+
+import org.jspecify.annotations.NonNull;
+
+import com.helger.base.enforce.ValueEnforcer;
+import com.helger.jcodemodel.*;
+
+
+/// Create an expression to initialize at most once a value from another
+/// expression.
+///
+/// For example, you want `getString()` to cache the result of the method `String
+/// longMethod() ` :
+/// ```java
+/// var lazy = new JLazy(myJDefinedClass, String.class, "getString")
+///    .static()
+///    .init(Jexpr.invoke("longMethod"));
+///
+/// ```
+///
+/// Upon creation, this class adds itself in the target [JDefinedClass] as an
+/// extra declaration
+///
+@SuppressWarnings("serial")
+public class JLazy implements IJDeclaration, IJOwned {
+
+  /// the class this is inserted into.
+  private final JDefinedClass clazz;
+
+  private final AbstractJClass expressionType;
+
+  /// the name of the method to call
+  private final String methodName;
+
+  /// the expression to call the lazy init, typically the method name
+  private final IJExpressionStatement expr;
+
+  /// when static, the field and methods are made static
+  private boolean _static = false;
+
+  /// when synchronized (default), the init is synchronized to avoid
+  /// multiple calls.
+  private boolean sync = true;
+
+  /// initialization of the value
+  private IJExpression init = null;
+
+  private static final String GETTER_PREFIX = "get";
+
+  static String extractFieldName(String methodName) {
+    if (methodName == null || methodName.isBlank()) {
+      return methodName;
+    }
+    if (methodName.startsWith(GETTER_PREFIX) && methodName.length() > GETTER_PREFIX.length()) {
+      methodName =
+          Character.toString(Character.toLowerCase(methodName.charAt(GETTER_PREFIX.length())))
+              + methodName.substring(GETTER_PREFIX.length() + 1);
+    }
+    if (!JJavaName.isJavaIdentifier(methodName)) {
+      methodName += "_";
+    }
+    return methodName;
+  }
+
+  public JLazy(JDefinedClass clazz, AbstractJClass expressionType, String methodName) {
+    ValueEnforcer.isTrue(JJavaName.isJavaIdentifier(methodName), () -> "Illegal variable name '" + methodName + "'");
+    this.clazz = clazz;
+    this.expressionType = expressionType;
+    this.methodName = methodName;
+    expr = JExpr.invoke(methodName);
+    clazz.getExtraDeclarations().add(this);
+  }
+
+  public JLazy(JDefinedClass clazz, Class<?> expressionType, String methodName) {
+    this(clazz, clazz.owner().ref(expressionType), methodName);
+  }
+
+  @Override
+  public @NonNull JCodeModel owner() {
+    return clazz.owner();
+  }
+
+  public IJExpression expr() {
+    return expr;
+  }
+
+  /// @return this for chaining
+  public JLazy _static() {
+    return _static(true);
+  }
+
+  /// @return this for chaining
+  public JLazy _static(boolean value) {
+    _static = value;
+    return this;
+  }
+
+  public boolean isStatic() {
+    return _static;
+  }
+
+  /// @return this for chaining
+  public JLazy sync(boolean value) {
+    sync = value;
+    return this;
+  }
+
+  /// @return this for chaining
+  public JLazy async() {
+    return sync(false);
+  }
+
+  public boolean sync() {
+    return sync;
+  }
+
+  /// @return this for chaining
+  public JLazy init(IJExpression value) {
+    init = value;
+    return this;
+  }
+
+  public IJExpression init() {
+    return init;
+  }
+
+  @Override
+  public String toString() {
+    return "lazy init " + methodName;
+  }
+
+  @Override
+  public void declare(@NonNull IJFormatter f) {
+    if (init == null) {
+      throw new NullPointerException("init of " + this + " is null");
+    }
+
+
+    int fieldMods = JMod.PRIVATE|JMod.VOLATILE;
+    if (_static) {
+      fieldMods |= JMod.STATIC;
+    }
+    JFieldVar jfv =
+        new JFieldVar(clazz, JMods.forField(fieldMods), expressionType, extractFieldName(methodName), null);
+    f.declaration(jfv);
+    f.newline();
+
+    int methodMods = JMod.PUBLIC;
+    if (_static) {
+      methodMods |= JMod.STATIC;
+    }
+    JMethod jm = new JMethod(clazz, methodMods, expressionType, methodName);
+    JBlock methodBody = jm.body();
+    String varName = methodName;
+    if(varName.equals(jfv.name())) {
+      varName+="_";
+    }
+    JVar jv = methodBody.decl(expressionType, varName).init(jfv);
+    JBlock initBlock = methodBody._if(jv.eqNull())._then();
+    if (sync) {
+      initBlock =
+          initBlock.synchronizedBlock(
+              _static
+                  ? clazz.dotclass()
+                  : JExpr._this())
+              .body();
+    }
+    initBlock._if(jv.eqNull())._then()
+        .assign(jv, init)
+        .assign(jfv, jv);
+    methodBody._return(jv);
+
+    f.declaration(jm);
+  }
+
+}

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/patterns/JLazy.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/patterns/JLazy.java
@@ -135,7 +135,6 @@ public class JLazy implements IJDeclaration, IJOwned {
       throw new NullPointerException("init of " + this + " is null");
     }
 
-
     int fieldMods = JMod.PRIVATE|JMod.VOLATILE;
     if (_static) {
       fieldMods |= JMod.STATIC;
@@ -144,6 +143,7 @@ public class JLazy implements IJDeclaration, IJOwned {
         new JFieldVar(clazz, JMods.forField(fieldMods), expressionType, extractFieldName(methodName), null);
     f.declaration(jfv);
     f.newline();
+    JFieldRef fieldRef = _static ? clazz.staticRef(jfv) : JExpr.refthis(jfv);
 
     int methodMods = JMod.PUBLIC;
     if (_static) {
@@ -151,11 +151,7 @@ public class JLazy implements IJDeclaration, IJOwned {
     }
     JMethod jm = new JMethod(clazz, methodMods, expressionType, methodName);
     JBlock methodBody = jm.body();
-    String varName = methodName;
-    if(varName.equals(jfv.name())) {
-      varName+="_";
-    }
-    JVar jv = methodBody.decl(expressionType, varName).init(jfv);
+    JVar jv = methodBody.decl(expressionType, "ret").init(fieldRef);
     JBlock initBlock = methodBody._if(jv.eqNull())._then();
     if (sync) {
       initBlock =
@@ -165,9 +161,10 @@ public class JLazy implements IJDeclaration, IJOwned {
                   : JExpr._this())
               .body();
     }
+    initBlock.assign(jv, fieldRef);
     initBlock._if(jv.eqNull())._then()
         .assign(jv, init)
-        .assign(jfv, jv);
+        .assign(fieldRef, jv);
     methodBody._return(jv);
 
     f.declaration(jm);

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/patterns/JLazyTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/patterns/JLazyTest.java
@@ -1,0 +1,34 @@
+package com.helger.jcodemodel.patterns;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JLazyTest {
+
+  @Test
+  public void testExtractFieldName() {
+
+    // standard cases
+
+    Assert.assertEquals("x", JLazy.extractFieldName("getX"));
+    Assert.assertEquals("x", JLazy.extractFieldName("getx"));
+    Assert.assertEquals("myFieldName", JLazy.extractFieldName("myFieldName"));
+    Assert.assertEquals("xy", JLazy.extractFieldName("getXy"));
+    Assert.assertEquals("xy", JLazy.extractFieldName("getxy"));
+    Assert.assertEquals("gETget", JLazy.extractFieldName("getGETget"));
+
+    // edge cases
+
+    // null/blank are kept as is
+    Assert.assertEquals(null, JLazy.extractFieldName(null));
+    Assert.assertEquals("  ", JLazy.extractFieldName("  "));
+    Assert.assertEquals("\t", JLazy.extractFieldName("\t"));
+    // too short are kept
+    Assert.assertEquals("get", JLazy.extractFieldName("get"));
+    Assert.assertEquals("x", JLazy.extractFieldName("x"));
+    // reserved keywords have _ appended
+    Assert.assertEquals("int_", JLazy.extractFieldName("int"));
+    Assert.assertEquals("class_", JLazy.extractFieldName("class"));
+  }
+
+}

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/lazy/GeneratedLazyClass.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/lazy/GeneratedLazyClass.java
@@ -26,58 +26,62 @@ public class GeneratedLazyClass {
     private volatile Integer syncInstance;
 
     public Integer getSyncInstance() {
-        Integer getSyncInstance = syncInstance;
-        if (getSyncInstance == null) {
+        Integer ret = this.syncInstance;
+        if (ret == null) {
             synchronized (this)
             {
-                if (getSyncInstance == null) {
-                    getSyncInstance = JLazyTestGen.inc();
-                    syncInstance = getSyncInstance;
+                ret = this.syncInstance;
+                if (ret == null) {
+                    ret = JLazyTestGen.inc();
+                    this.syncInstance = ret;
                 }
             }
         }
-        return getSyncInstance;
+        return ret;
     }
 
     private static volatile Integer syncStatic;
 
     public static Integer getSyncStatic() {
-        Integer getSyncStatic = syncStatic;
-        if (getSyncStatic == null) {
+        Integer ret = GeneratedLazyClass.syncStatic;
+        if (ret == null) {
             synchronized (GeneratedLazyClass.class)
             {
-                if (getSyncStatic == null) {
-                    getSyncStatic = JLazyTestGen.inc();
-                    syncStatic = getSyncStatic;
+                ret = GeneratedLazyClass.syncStatic;
+                if (ret == null) {
+                    ret = JLazyTestGen.inc();
+                    GeneratedLazyClass.syncStatic = ret;
                 }
             }
         }
-        return getSyncStatic;
+        return ret;
     }
 
     private volatile Integer aSyncInstance;
 
     public Integer getASyncInstance() {
-        Integer getASyncInstance = aSyncInstance;
-        if (getASyncInstance == null) {
-            if (getASyncInstance == null) {
-                getASyncInstance = JLazyTestGen.inc();
-                aSyncInstance = getASyncInstance;
+        Integer ret = this.aSyncInstance;
+        if (ret == null) {
+            ret = this.aSyncInstance;
+            if (ret == null) {
+                ret = JLazyTestGen.inc();
+                this.aSyncInstance = ret;
             }
         }
-        return getASyncInstance;
+        return ret;
     }
 
     private static volatile Integer aSyncStatic;
 
     public static Integer getASyncStatic() {
-        Integer getASyncStatic = aSyncStatic;
-        if (getASyncStatic == null) {
-            if (getASyncStatic == null) {
-                getASyncStatic = JLazyTestGen.inc();
-                aSyncStatic = getASyncStatic;
+        Integer ret = GeneratedLazyClass.aSyncStatic;
+        if (ret == null) {
+            ret = GeneratedLazyClass.aSyncStatic;
+            if (ret == null) {
+                ret = JLazyTestGen.inc();
+                GeneratedLazyClass.aSyncStatic = ret;
             }
         }
-        return getASyncStatic;
+        return ret;
     }
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/lazy/GeneratedLazyClass.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/lazy/GeneratedLazyClass.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.helger.jcodemodel.tests.lazy;
+
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
+public class GeneratedLazyClass {
+
+    public int sum() {
+        return (((getSyncInstance()+ getSyncStatic())+ getASyncInstance())+ getASyncStatic());
+    }
+
+    private volatile Integer syncInstance;
+
+    public Integer getSyncInstance() {
+        Integer getSyncInstance = syncInstance;
+        if (getSyncInstance == null) {
+            synchronized (this)
+            {
+                if (getSyncInstance == null) {
+                    getSyncInstance = JLazyTestGen.inc();
+                    syncInstance = getSyncInstance;
+                }
+            }
+        }
+        return getSyncInstance;
+    }
+
+    private static volatile Integer syncStatic;
+
+    public static Integer getSyncStatic() {
+        Integer getSyncStatic = syncStatic;
+        if (getSyncStatic == null) {
+            synchronized (GeneratedLazyClass.class)
+            {
+                if (getSyncStatic == null) {
+                    getSyncStatic = JLazyTestGen.inc();
+                    syncStatic = getSyncStatic;
+                }
+            }
+        }
+        return getSyncStatic;
+    }
+
+    private volatile Integer aSyncInstance;
+
+    public Integer getASyncInstance() {
+        Integer getASyncInstance = aSyncInstance;
+        if (getASyncInstance == null) {
+            if (getASyncInstance == null) {
+                getASyncInstance = JLazyTestGen.inc();
+                aSyncInstance = getASyncInstance;
+            }
+        }
+        return getASyncInstance;
+    }
+
+    private static volatile Integer aSyncStatic;
+
+    public static Integer getASyncStatic() {
+        Integer getASyncStatic = aSyncStatic;
+        if (getASyncStatic == null) {
+            if (getASyncStatic == null) {
+                getASyncStatic = JLazyTestGen.inc();
+                aSyncStatic = getASyncStatic;
+            }
+        }
+        return getASyncStatic;
+    }
+}

--- a/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/lazy/JLazyTestGen.java
+++ b/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/lazy/JLazyTestGen.java
@@ -1,0 +1,50 @@
+package com.helger.jcodemodel.tests.lazy;
+
+import com.helger.jcodemodel.IJExpression;
+import com.helger.jcodemodel.JDefinedClass;
+import com.helger.jcodemodel.JMod;
+import com.helger.jcodemodel.JPackage;
+import com.helger.jcodemodel.compile.annotation.TestJCM;
+import com.helger.jcodemodel.exceptions.JCodeModelException;
+import com.helger.jcodemodel.patterns.JLazy;
+
+@TestJCM
+public class JLazyTestGen {
+
+  // methods for the tests to call.
+
+  public static int count = 0;
+
+  public static int inc() {
+    return ++count;
+  }
+
+  public void testLazyClass(JPackage root) throws JCodeModelException {
+    JDefinedClass lazyClass = root._class("GeneratedLazyClass");
+
+    var syncinstance =
+        new JLazy(lazyClass, Integer.class, "getSyncInstance")
+        .init(root.owner().ref(JLazyTestGen.class).staticInvoke("inc"));
+    var syncstatic =
+        new JLazy(lazyClass, Integer.class, "getSyncStatic")
+        ._static()
+        .init(root.owner().ref(JLazyTestGen.class).staticInvoke("inc"));
+    var asyncinstance =
+        new JLazy(lazyClass, Integer.class, "getASyncInstance")
+        .sync(false)
+        .init(root.owner().ref(JLazyTestGen.class).staticInvoke("inc"));
+    var asyncstatic =
+        new JLazy(lazyClass, Integer.class, "getASyncStatic")
+        ._static()
+        .sync(false)
+        .init(root.owner().ref(JLazyTestGen.class).staticInvoke("inc"));
+
+    IJExpression sum =
+        syncinstance.expr()
+        .plus(syncstatic.expr())
+        .plus(asyncinstance.expr())
+        .plus(asyncstatic.expr());
+    lazyClass.method(JMod.PUBLIC, root.owner().INT, "sum").body()._return(sum);
+  }
+
+}

--- a/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/lazy/JLazyTest.java
+++ b/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/lazy/JLazyTest.java
@@ -22,10 +22,10 @@ public class JLazyTest {
   public void testInstance() {
     GeneratedLazyClass test = new GeneratedLazyClass();
     Set<Integer> values =
-        IntStream.rangeClosed(0, 1000).parallel()
+        IntStream.rangeClosed(0, 10000).parallel()
             .mapToObj(i -> test.getSyncInstance())
             .collect(Collectors.toSet());
-    Assert.assertEquals(1, values.size());
+    Assert.assertEquals("received " + values, 1, values.size());
   }
 
 }

--- a/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/lazy/JLazyTest.java
+++ b/jcodemodeltests/src/test/java/com/helger/jcodemodel/tests/lazy/JLazyTest.java
@@ -1,0 +1,31 @@
+package com.helger.jcodemodel.tests.lazy;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JLazyTest {
+
+  @Test
+  public void testStatic() {
+    Set<Integer> values =
+        IntStream.rangeClosed(0, 1000).parallel()
+            .mapToObj(i -> GeneratedLazyClass.getSyncStatic())
+            .collect(Collectors.toSet());
+    Assert.assertEquals(1, values.size());
+  }
+
+  @Test
+  public void testInstance() {
+    GeneratedLazyClass test = new GeneratedLazyClass();
+    Set<Integer> values =
+        IntStream.rangeClosed(0, 1000).parallel()
+            .mapToObj(i -> test.getSyncInstance())
+            .collect(Collectors.toSet());
+    Assert.assertEquals(1, values.size());
+  }
+
+}


### PR DESCRIPTION
Make JFieldVar and JMethod constructor visible to construct them in the export of the lazy without adding them to the class

Add extraDeclarations to the JDefinedClass to add the lazy(s). JLazy auto adds itself in the jdc.

Add tests on the JLazy static method, and generation usage + generated tests in jcodemodeltests.