### PR TITLE
added type inference("var")

### DIFF
--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JBlock.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JBlock.java
@@ -249,13 +249,13 @@ public class JBlock implements IJGenerable, IJStatement
    * enabled!
    *
    * @param aType
-   *        JType of the variable
+   *        JType of the variable, or null to use var.
    * @param sName
    *        Name of the variable
    * @return Newly generated {@link JVar}
    */
   @NonNull
-  public JVar decl (@NonNull final AbstractJType aType, @NonNull final String sName)
+  public JVar decl (final AbstractJType aType, @NonNull final String sName)
   {
     return decl (JMod.NONE, aType, sName, null);
   }
@@ -301,18 +301,18 @@ public class JBlock implements IJGenerable, IJStatement
    * enabled!
    *
    * @param nMods
-   *        Modifiers for the variable
+   *              Modifiers for the variable
    * @param aType
-   *        JType of the variable
+   *              JType of the variable, or null to use var.
    * @param sName
-   *        Name of the variable
+   *              Name of the variable
    * @param aInit
-   *        Initialization expression for this variable. May be null.
+   *              Initialization expression for this variable. May be null.
    * @return Newly generated {@link JVar}
    */
   @NonNull
   public JVar decl (final int nMods,
-                    @NonNull final AbstractJType aType,
+                    final AbstractJType aType,
                     @NonNull final String sName,
                     @Nullable final IJExpression aInit)
   {
@@ -966,8 +966,8 @@ public class JBlock implements IJGenerable, IJStatement
         f.outdent ();
       if (m_bBracesRequired)
         f.print ('}');
+      }
     }
-  }
 
   protected void generateBody (@NonNull final IJFormatter f)
   {
@@ -991,5 +991,5 @@ public class JBlock implements IJGenerable, IJStatement
     f.generable (this);
     if (m_bBracesRequired)
       f.newline ();
+    }
   }
-}

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JFieldVar.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JFieldVar.java
@@ -80,7 +80,7 @@ public class JFieldVar extends JVar implements IJDocCommentable
                        @NonNull final String sName,
                        @Nullable final IJExpression aInit)
   {
-    super (aMods, aType, sName, aInit);
+    super(aMods, ValueEnforcer.notNull(aType, "type"), sName, aInit);
     m_aOwnerClass = ValueEnforcer.notNull (aOwnerClass, "OwnerClass");
   }
 

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JMethod.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JMethod.java
@@ -236,7 +236,7 @@ public class JMethod extends AbstractJGenerifiableImpl implements IJAnnotatable,
   @NonNull
   public JVar param (final int nMods, @NonNull final AbstractJType aType, @NonNull final String sName)
   {
-    final JVar aVar = new JVar (JMods.forVar (nMods), aType, sName, null);
+    final JVar aVar = new JVar (JMods.forVar (nMods), ValueEnforcer.notNull(aType, "type"), sName, null);
     m_aParams.add (aVar);
     return aVar;
   }

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JVar.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JVar.java
@@ -63,7 +63,7 @@ public class JVar implements IJAssignmentTarget, IJDeclaration, IJAnnotatable
   private final JMods m_aMods;
 
   /**
-   * Type of the variable
+   * Type of the variable. When set to null, use "var" instead.
    */
   private AbstractJType m_aType;
 
@@ -88,14 +88,14 @@ public class JVar implements IJAssignmentTarget, IJDeclaration, IJAnnotatable
    * @param aMods
    *        Modifiers to use
    * @param aType
-   *        Data type of this variable
+   *        Data type of this variable, or null to use var.
    * @param sName
    *        Name of this variable
    * @param aInitExpr
    *        Value to initialize this variable to
    */
   public JVar (@NonNull final JMods aMods,
-      @NonNull final AbstractJType aType,
+      final AbstractJType aType,
       @NonNull final String sName,
       @Nullable final IJExpression aInitExpr)
   {
@@ -153,11 +153,8 @@ public class JVar implements IJAssignmentTarget, IJDeclaration, IJAnnotatable
   }
 
   /**
-   * Return the type of this variable.
-   *
-   * @return always non-null.
+   * @return the type of this variable, or null if the variable type is infered.
    */
-  @NonNull
   public AbstractJType type ()
   {
     return m_aType;
@@ -180,8 +177,7 @@ public class JVar implements IJAssignmentTarget, IJDeclaration, IJAnnotatable
    *        must not be null.
    * @return the old type value. always non-null.
    */
-  @NonNull
-  public AbstractJType type (@NonNull final AbstractJType aNewType)
+  public AbstractJType type (final AbstractJType aNewType)
   {
     ValueEnforcer.notNull (aNewType, "NewType");
     final AbstractJType aOldType = m_aType;
@@ -205,8 +201,9 @@ public class JVar implements IJAssignmentTarget, IJDeclaration, IJAnnotatable
   @NonNull
   public JAnnotationUse annotate (@NonNull final AbstractJClass aClazz)
   {
-    if (m_aAnnotations == null)
+    if (m_aAnnotations == null) {
       m_aAnnotations = new ArrayList <> ();
+    }
     final JAnnotationUse a = new JAnnotationUse (aClazz);
     m_aAnnotations.add (a);
     return a;
@@ -223,14 +220,18 @@ public class JVar implements IJAssignmentTarget, IJDeclaration, IJAnnotatable
   @NonNull
   public JAnnotationUse annotate (@NonNull final Class <? extends Annotation> aClazz)
   {
+    if(m_aType==null) {
+      throw new UnsupportedOperationException("can't reference class "+aClazz.getCanonicalName()+" without a JCM owner, use JVar::annotate(AbstractJClass) instead");
+    }
     return annotate (m_aType.owner ().ref (aClazz));
   }
 
   @NonNull
   public List <JAnnotationUse> annotationsMutable ()
   {
-    if (m_aAnnotations == null)
+    if (m_aAnnotations == null) {
       m_aAnnotations = new ArrayList <> ();
+    }
     return m_aAnnotations;
   }
 
@@ -248,21 +249,32 @@ public class JVar implements IJAssignmentTarget, IJDeclaration, IJAnnotatable
 
   public void bind (@NonNull final IJFormatter f)
   {
+    if(m_aType==null && m_aInitExpr==null) {
+      throw new RuntimeException("can't declare a variable with no type and no init");
+    }
     if (m_aAnnotations != null)
     {
       final boolean bNewLine = this instanceof JFieldVar;
       for (final JAnnotationUse annotation : m_aAnnotations)
       {
         f.generable (annotation);
-        if (bNewLine)
+        if (bNewLine) {
           f.newline ();
-        else
+        } else {
           f.print (' ');
+        }
       }
     }
-    f.generable (m_aMods).generable (m_aType).id (m_sName);
-    if (m_aInitExpr != null)
+    f.generable(m_aMods);
+    if (m_aType != null) {
+      f.generable(m_aType);
+    } else {
+      f.print("var");
+    }
+    f.id(m_sName);
+    if (m_aInitExpr != null) {
       f.print ('=').generable (m_aInitExpr);
+    }
   }
 
   @Override
@@ -280,10 +292,12 @@ public class JVar implements IJAssignmentTarget, IJDeclaration, IJAnnotatable
   @Override
   public boolean equals (final Object o)
   {
-    if (o == this)
+    if (o == this) {
       return true;
-    if (o == null || getClass () != o.getClass ())
+    }
+    if (o == null || getClass () != o.getClass ()) {
       return false;
+    }
     final JVar rhs = (JVar) o;
     return EqualsHelper.equals (m_sName, rhs.m_sName);
   }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/typeinference/VarTest.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/typeinference/VarTest.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.helger.jcodemodel.tests.typeinference;
+
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
+public class VarTest {
+
+    public void test() {
+        int baseInt = 42;
+        var testVar = 42;
+    }
+}

--- a/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/typeinference/JVarVarTestGen.java
+++ b/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/typeinference/JVarVarTestGen.java
@@ -1,0 +1,19 @@
+package com.helger.jcodemodel.tests.typeinference;
+
+import com.helger.jcodemodel.JExpr;
+import com.helger.jcodemodel.JMod;
+import com.helger.jcodemodel.JPackage;
+import com.helger.jcodemodel.compile.annotation.TestJCM;
+import com.helger.jcodemodel.exceptions.JCodeModelException;
+
+@TestJCM
+public class JVarVarTestGen {
+
+  public void VarTest(final JPackage root) throws JCodeModelException {
+    var cl = root._class("VarTest");
+    var jm = cl.method(JMod.PUBLIC, root.owner().VOID, "test");
+    jm.body().decl(root.owner().INT, "baseInt").init(JExpr.lit(42));
+    jm.body().decl(null, "testVar").init(JExpr.lit(42));
+  }
+
+}


### PR DESCRIPTION
JVar relaxed non-null constraint on the type ; however fails if declaring a variable without type AND without init.

JFieldVar got this constraint instead, since class variables can't be var (only local method variables)

Same, JMethod.param() has a check on null since method params can't be var.