### PR TITLE
fix #169

### DIFF
--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JExpr.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JExpr.java
@@ -50,7 +50,7 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import com.helger.annotation.Nonnegative;
-import com.helger.jcodemodel.expression.JArrayInit;
+import com.helger.jcodemodel.expressions.JArrayInit;
 import com.helger.jcodemodel.expressions.JInstanceOfVar;
 
 /**

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JMethod.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JMethod.java
@@ -242,7 +242,7 @@ public class JMethod extends AbstractJGenerifiableImpl implements IJAnnotatable,
   @NonNull
   public JArgVar param(final int nMods, @NonNull final AbstractJType aType, @NonNull final String sName)
   {
-    final JArgVar aVar = new JArgVar((nMods | JMod.FINAL) > 0, ValueEnforcer.notNull(aType, "type"), sName);
+    final JArgVar aVar = new JArgVar ( (nMods & JMod.FINAL) > 0, ValueEnforcer.notNull (aType, "type"), sName);
     m_aParams.add (aVar);
     return aVar;
   }
@@ -350,7 +350,7 @@ public class JMethod extends AbstractJGenerifiableImpl implements IJAnnotatable,
                             Check if varParam method of JMethod is\
                              invoked more than once""");
 
-    m_aVarParam = new JVarArgVar((nMods | JMod.FINAL) > 0, aType.array(), sName);
+    m_aVarParam = new JVarArgVar ( (nMods & JMod.FINAL) > 0, aType.array (), sName);
     return m_aVarParam;
   }
 
@@ -416,9 +416,8 @@ public class JMethod extends AbstractJGenerifiableImpl implements IJAnnotatable,
   @NonNull
   public List <JAnnotationUse> annotationsMutable ()
   {
-    if (m_aAnnotations == null) {
+    if (m_aAnnotations == null)
       return Collections.emptyList ();
-    }
     return m_aAnnotations;
   }
 
@@ -503,14 +502,12 @@ public class JMethod extends AbstractJGenerifiableImpl implements IJAnnotatable,
   public boolean hasSignature (@NonNull final AbstractJType [] argTypes)
   {
     final JVar [] aParams = listParams ();
-    if (aParams.length != argTypes.length) {
+    if (aParams.length != argTypes.length)
       return false;
-    }
 
     for (int i = 0; i < aParams.length; i++) {
-      if (!aParams[i].type ().equals (argTypes[i])) {
+      if (!aParams[i].type ().equals (argTypes[i]))
         return false;
-      }
     }
 
     return true;
@@ -587,7 +584,7 @@ public class JMethod extends AbstractJGenerifiableImpl implements IJAnnotatable,
       boolean wrapName = switch (nameWrapStrat) {
       case ALWAYS -> true;
       case NEVER -> false;
-      case REQUIRED -> f.currentLineSize() + m_sName.length() + 1 > f.settings().wrap.lineWidth;
+      case REQUIRED -> (f.currentLineSize() + m_sName.length() + 1) > f.settings().wrap.lineWidth;
       };
       if (wrapName) {
         int nbi = f.settings().wrap.method.name.indent;
@@ -629,7 +626,7 @@ public class JMethod extends AbstractJGenerifiableImpl implements IJAnnotatable,
         boolean wrapBracket = switch (bracketWrapStrat) {
         case ALWAYS -> true;
         case NEVER -> false;
-        case REQUIRED -> f.currentLineSize() + 2 > f.settings().wrap.lineWidth;
+        case REQUIRED -> (f.currentLineSize() + 2) > f.settings().wrap.lineWidth;
         };
         if (wrapBracket) {
           f
@@ -642,7 +639,7 @@ public class JMethod extends AbstractJGenerifiableImpl implements IJAnnotatable,
     }
     else
     {
-      final boolean bIsDeclarationOnly = m_aOwningClass.isInterface () && !m_aMods.isDefault () ||
+      final boolean bIsDeclarationOnly = (m_aOwningClass.isInterface () && !m_aMods.isDefault ()) ||
                                          m_aOwningClass.isAnnotationTypeDeclaration () ||
                                          m_aMods.isAbstract () ||
                                          m_aMods.isNative ();
@@ -658,7 +655,7 @@ public class JMethod extends AbstractJGenerifiableImpl implements IJAnnotatable,
           boolean wrapBracket = switch (bracketWrapStrat) {
           case ALWAYS -> true;
           case NEVER -> false;
-          case REQUIRED -> f.currentLineSize() + 2 > f.settings().wrap.lineWidth;
+          case REQUIRED -> (f.currentLineSize() + 2) > f.settings().wrap.lineWidth;
           };
           if (wrapBracket) {
             f
@@ -681,7 +678,7 @@ public class JMethod extends AbstractJGenerifiableImpl implements IJAnnotatable,
 
     boolean bFirst = true;
     // break only if more than 3 variables are present
-    final boolean bNewLineAfterParam = m_aParams.size() + (hasVarArgs() ? 1 : 0) > 3;
+    final boolean bNewLineAfterParam = (m_aParams.size() + (hasVarArgs() ? 1 : 0)) > 3;
     for (final JVar var : m_aParams) {
       if (bFirst) {
         bFirst = false;

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/expressions/JArrayInit.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/expressions/JArrayInit.java
@@ -38,7 +38,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-package com.helger.jcodemodel.expression;
+package com.helger.jcodemodel.expressions;
 
 import java.util.List;
 import java.util.stream.Stream;

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/expressions/JInstanceOfVar.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/expressions/JInstanceOfVar.java
@@ -45,32 +45,34 @@ import org.jspecify.annotations.NonNull;
 import com.helger.jcodemodel.AbstractJType;
 import com.helger.jcodemodel.IJExpression;
 import com.helger.jcodemodel.IJFormatter;
-import com.helger.jcodemodel.JMods;
-import com.helger.jcodemodel.JVar;
+import com.helger.jcodemodel.vars.JPatternVar;
 
+/// test if an expression is instance of a type, and produce a new pattern variable when so.
 public class JInstanceOfVar implements IJExpression {
 
-  private final IJExpression m_oExpr;
-  private final JVar m_oVar;
+  private final IJExpression m_aExpr;
+
+  private final JPatternVar m_aVar;
 
   public JInstanceOfVar(@NonNull final IJExpression expr,
       @NonNull final AbstractJType type,
       @NonNull final String name) {
-    m_oExpr = expr;
-    m_oVar = new JVar(JMods.forVar(0), type, name, null);
+    m_aExpr = expr;
+    m_aVar = new JPatternVar (false, type, name);
   }
 
   public IJExpression expr() {
-    return m_oExpr;
+    return m_aExpr;
   }
 
-  public JVar var() {
-    return m_oVar;
+  public JPatternVar var ()
+  {
+    return m_aVar;
   }
 
   @Override
   public void generate(@NonNull IJFormatter f) {
-    f.print('(').generable(m_oExpr).print("instanceof").var(m_oVar).print(')');
+    f.print('(').generable(m_aExpr).print("instanceof").var(m_aVar).print(')');
   }
 
 }

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/vars/JArgVar.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/vars/JArgVar.java
@@ -59,7 +59,7 @@ import com.helger.jcodemodel.JVar;
 public class JArgVar extends JVar {
 
   public JArgVar(boolean final_, @NonNull AbstractJType aType, @NonNull String sName) {
-    super(JMods.forVar(final_ ? JMod.NONE : JMod.FINAL), aType, sName, null);
+    super (JMods.forVar (final_ ? JMod.FINAL : JMod.NONE), aType, sName, null);
   }
 
   @Override

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/vars/JPatternVar.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/vars/JPatternVar.java
@@ -1,0 +1,44 @@
+
+package com.helger.jcodemodel.vars;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import com.helger.jcodemodel.AbstractJType;
+import com.helger.jcodemodel.IJExpression;
+import com.helger.jcodemodel.JMod;
+import com.helger.jcodemodel.JMods;
+import com.helger.jcodemodel.JVar;
+
+/// Pattern variable, declared when matching another variable to a type
+///
+/// ```java
+/// if( o instanceof int i) {} // the var is i, type int, no init
+/// switch(o){case Integer i -> {} } //var is i, type Integer
+/// ```
+///
+///  - only allowed mod is final
+///  - type is required
+///  - init is null
+///
+/// @see https://docs.oracle.com/javase/specs/jls/se17/html/jls-14.html#jls-14.30.1
+///
+public class JPatternVar extends JVar
+{
+  public JPatternVar (
+      boolean isFinal,
+      @NonNull AbstractJType aType,
+      @NonNull String sName)
+  {
+    super (JMods.forVar (isFinal ? JMod.FINAL : JMod.NONE), aType, sName, null);
+  }
+
+  @Override
+  public @NonNull JPatternVar init (@Nullable IJExpression aInitExpr)
+  {
+    if (aInitExpr != null)
+      throw new UnsupportedOperationException (getClass ().getSimpleName () + " can't receive a non-null init");
+    return this;
+  }
+
+}

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/vars/JSameVar.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/vars/JSameVar.java
@@ -54,7 +54,7 @@ import com.helger.jcodemodel.JVar;
 /// ```java
 /// int i=0, j, k=1;
 /// ```
-/// Here i is a block variable, j and k are "same" var.
+/// Here i is a block variable, j and k are "same" vars.
 public class JSameVar extends JVar
 {
   private final JVar m_aParent;
@@ -68,8 +68,8 @@ public class JSameVar extends JVar
                    @Nonnegative final int nDim)
   {
     super (parent.mods (), typeArray (parent.type (), nDim), sName, aInitExpr);
-    this.m_aParent = parent;
-    this.m_nDim = nDim;
+    m_aParent = parent;
+    m_nDim = nDim;
   }
 
   public JSameVar (final JVar parent, final String sName, final IVariableInitializer aInitExpr)

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/vars/JVarArgVar.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/vars/JVarArgVar.java
@@ -45,8 +45,7 @@ import org.jspecify.annotations.NonNull;
 import com.helger.jcodemodel.AbstractJType;
 import com.helger.jcodemodel.IJFormatter;
 
-///
-/// A variable that is the last argument of a method signature, with variable length.
+/// A variable last argument of a method signature, with variable length (array).
 ///
 /// same constraints as for the [JArgVar]
 ///

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/format/catchclause/DefaultWrapOptions.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/format/catchclause/DefaultWrapOptions.java
@@ -23,9 +23,9 @@ public class DefaultWrapOptions {
 
     public static final void multiplecatch() {
         try {
-        } catch (ClassCastException ex) {
-        } catch (ArithmeticException exception1) {
-        } catch (ArrayIndexOutOfBoundsException | ArrayStoreException | BufferOverflowException | BufferUnderflowException ex) {
+        } catch (final ClassCastException ex) {
+        } catch (final ArithmeticException exception1) {
+        } catch (final ArrayIndexOutOfBoundsException | ArrayStoreException | BufferOverflowException | BufferUnderflowException ex) {
         }
     }
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/format/catchclause/DisabledWrap.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/format/catchclause/DisabledWrap.java
@@ -23,9 +23,9 @@ public class DisabledWrap {
 
     public static final void multiplecatch() {
         try {
-        } catch (ClassCastException ex) {
-        } catch (ArithmeticException exception1) {
-        } catch (ArrayIndexOutOfBoundsException | ArrayStoreException | BufferOverflowException | BufferUnderflowException ex) {
+        } catch (final ClassCastException ex) {
+        } catch (final ArithmeticException exception1) {
+        } catch (final ArrayIndexOutOfBoundsException | ArrayStoreException | BufferOverflowException | BufferUnderflowException ex) {
         }
     }
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/format/catchclause/WrapTypesBinary.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/format/catchclause/WrapTypesBinary.java
@@ -23,9 +23,9 @@ public class WrapTypesBinary {
 
     public static final void multiplecatch() {
         try {
-        } catch (ClassCastException ex) {
-        } catch (ArithmeticException exception1) {
-        } catch (
+        } catch (final ClassCastException ex) {
+        } catch (final ArithmeticException exception1) {
+        } catch (final
             ArrayIndexOutOfBoundsException | 
             ArrayStoreException | 
             BufferOverflowException | 

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/format/catchclause/WrapTypesRequired.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/format/catchclause/WrapTypesRequired.java
@@ -23,9 +23,9 @@ public class WrapTypesRequired {
 
     public static final void multiplecatch() {
         try {
-        } catch (ClassCastException ex) {
-        } catch (ArithmeticException exception1) {
-        } catch (ArrayIndexOutOfBoundsException | ArrayStoreException | 
+        } catch (final ClassCastException ex) {
+        } catch (final ArithmeticException exception1) {
+        } catch (final ArrayIndexOutOfBoundsException | ArrayStoreException | 
             BufferOverflowException | BufferUnderflowException ex) {
         }
     }


### PR DESCRIPTION
created a new pattern var for pattern( instanceof, switch), only used in the instanceofvar

fixed final mischeck ( | instead of & ) in variable mods detection.

moved "expresssion" pck into "expressions"