### PR TITLE
exception on naming a class "var"

### DIFF
--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JDefinedClass.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JDefinedClass.java
@@ -177,7 +177,7 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
     }
   };
 
-  protected JDefinedClass (@NonNull final IJClassContainer <?> aParent,
+  JDefinedClass (@NonNull final IJClassContainer <?> aParent,
                            final int nMods,
                            @Nullable final String sName,
                            @NonNull final EClassType eClassType)
@@ -195,7 +195,7 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
    * @param sName
    *        Name of this class
    */
-  protected JDefinedClass (@NonNull final JCodeModel aOwner, final int nMods, @Nullable final String sName)
+  JDefinedClass (@NonNull final JCodeModel aOwner, final int nMods, @Nullable final String sName)
   {
     this (aOwner, null, nMods, EClassType.CLASS, sName);
   }
@@ -214,7 +214,7 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
    * @param sName
    *        Name of this class
    */
-  private JDefinedClass (@NonNull final JCodeModel aOwner,
+  JDefinedClass (@NonNull final JCodeModel aOwner,
                          @Nullable final IJClassContainer <?> aOuter,
                          final int nMods,
                          @NonNull final EClassType eClassType,
@@ -226,24 +226,8 @@ public class JDefinedClass extends AbstractJClassContainer <JDefinedClass> imple
     {
       ValueEnforcer.notEmpty (sName, "Name");
 
-      if (!Character.isJavaIdentifierStart (sName.charAt (0)))
-      {
-        final String msg = "JDefinedClass name " +
-                           sName +
-                           " contains illegal character" +
-                           " for beginning of identifier: " +
-                           sName.charAt (0);
-        throw new IllegalArgumentException (msg);
-      }
-      for (int i = 1; i < sName.length (); i++)
-      {
-        final char c = sName.charAt (i);
-        if (!Character.isJavaIdentifierPart (c))
-        {
-          final String msg = "JDefinedClass name " + sName + " contains illegal character " + c;
-          throw new IllegalArgumentException (msg);
-        }
-      }
+      if (!JJavaName.isTypeIdentifier (sName))
+        throw new IllegalArgumentException ("JDefinedClass name " + sName + " is invalid type name");
     }
 
     if (isInterface ())

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JJavaName.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JJavaName.java
@@ -116,6 +116,20 @@ public final class JJavaName
     return true;
   }
 
+  /// verifies that a name is valid type identifier
+  ///
+  /// https://docs.oracle.com/javase/specs/jls/se17/html/jls-3.html#jls-3.8
+  ///
+  /// > A type identifier is an identifier that is not the character sequence var.
+  ///
+  /// > Type identifiers are used in certain contexts involving the declaration or use of types. For
+  /// > example, the name of a class must be a TypeIdentifier, so it is illegal to declare a class
+  /// > named var.
+  public static boolean isTypeIdentifier (@NonNull final String sStr)
+  {
+    return isJavaIdentifier (sStr) && !"var".equals (sStr);
+  }
+
   /**
    * Checks if the given string is a valid fully qualified name.
    *

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JDefinedClassTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JDefinedClassTest.java
@@ -210,12 +210,12 @@ public final class JDefinedClassTest
   public void testTypeNameVar () throws JCodeModelException
   {
     JCodeModel jcm = new JCodeModel ();
-    Assert.assertThrows (IllegalArgumentException.class, () -> new JDefinedClass (jcm, 0, "double"));
-    Assert.assertThrows (IllegalArgumentException.class, () -> new JDefinedClass (jcm, 0, "package"));
-    Assert.assertThrows (IllegalArgumentException.class, () -> new JDefinedClass (jcm, 0, "var"));
-    new JDefinedClass (jcm, 0, "Double");
-    new JDefinedClass (jcm, 0, "Package");
-    new JDefinedClass (jcm, 0, "Var");
+    Assert.assertThrows (IllegalArgumentException.class, () -> new JDefinedClass (jcm, JMod.NONE, "double"));
+    Assert.assertThrows (IllegalArgumentException.class, () -> new JDefinedClass (jcm, JMod.NONE, "package"));
+    Assert.assertThrows (IllegalArgumentException.class, () -> new JDefinedClass (jcm, JMod.NONE, "var"));
+    new JDefinedClass (jcm, JMod.NONE, "Double");
+    new JDefinedClass (jcm, JMod.NONE, "Package");
+    new JDefinedClass (jcm, JMod.NONE, "Var");
   }
 
 }

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JDefinedClassTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JDefinedClassTest.java
@@ -206,4 +206,16 @@ public final class JDefinedClassTest
     Assert.assertTrue (jdc.isEMod (EMod.SEALED, EMod.PRIVATE));
   }
 
+  @Test
+  public void testTypeNameVar () throws JCodeModelException
+  {
+    JCodeModel jcm = new JCodeModel ();
+    Assert.assertThrows (IllegalArgumentException.class, () -> new JDefinedClass (jcm, 0, "double"));
+    Assert.assertThrows (IllegalArgumentException.class, () -> new JDefinedClass (jcm, 0, "package"));
+    Assert.assertThrows (IllegalArgumentException.class, () -> new JDefinedClass (jcm, 0, "var"));
+    new JDefinedClass (jcm, 0, "Double");
+    new JDefinedClass (jcm, 0, "Package");
+    new JDefinedClass (jcm, 0, "Var");
+  }
+
 }


### PR DESCRIPTION
"var" is no more allowed as a class name, though "Var" is.

New static check for type identifier in JJAvaName, tests. Doc for the check regarding the spec.

Tests required to make JDefinedclass constructors visible so package-protected instead of private/protected. Was not sure which one to use, so put them all.

Tests were made before the new code and were failing, validating that the constructor did allow to build jdefined class with name "var", though there may have been more complex checks somewhere else.