### PR TITLE
added selective representation of int (bin, dec, hex, oct)

### DIFF
--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomInt.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomInt.java
@@ -42,6 +42,8 @@ package com.helger.jcodemodel;
 
 import static com.helger.jcodemodel.util.JCHashCodeGenerator.getHashCode;
 
+import java.util.function.IntFunction;
+
 import org.jspecify.annotations.NonNull;
 
 import com.helger.base.equals.EqualsHelper;
@@ -51,11 +53,71 @@ import com.helger.base.equals.EqualsHelper;
  */
 public class JAtomInt implements IJExpression
 {
+
+  /// @see https://docs.oracle.com/javase/specs/jls/se17/html/jls-3.html#jls-3.10.1
+  public static enum Representation
+  {
+    BINARY ("0b", Integer::toBinaryString),
+    DECIMAL ("", Integer::toString),
+    HEX ("0x", Integer::toHexString),
+    OCTAL ("0", Integer::toOctalString);
+
+    @NonNull
+    final IntFunction <String> representer;
+
+    @NonNull
+    final String prefix;
+
+    Representation (String prefix, IntFunction <String> representer)
+    {
+      this.prefix = prefix;
+      this.representer = representer;
+    }
+
+    public String represent (int i)
+    {
+      if (i < 0)
+        return "-" + represent (-i);
+      return prefix + representer.apply (i);
+    }
+  }
+
   private final int m_nValue;
+
+  @NonNull
+  private Representation representation = Representation.DECIMAL;
 
   protected JAtomInt (final int nWhat)
   {
     m_nValue = nWhat;
+  }
+
+  public JAtomInt representation (Representation representation)
+  {
+    if (representation != null)
+      this.representation = representation;
+    int i = 07;
+    return this;
+  }
+
+  public JAtomInt binary ()
+  {
+    return representation (Representation.BINARY);
+  }
+
+  public JAtomInt decimal ()
+  {
+    return representation (Representation.DECIMAL);
+  }
+
+  public JAtomInt hex ()
+  {
+    return representation (Representation.HEX);
+  }
+
+  public JAtomInt octal ()
+  {
+    return representation (Representation.OCTAL);
   }
 
   public int what ()
@@ -65,7 +127,7 @@ public class JAtomInt implements IJExpression
 
   public void generate (@NonNull final IJFormatter f)
   {
-    f.print (Integer.toString (m_nValue));
+    f.print (representation.represent (m_nValue));
   }
 
   @Override

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomInt.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomInt.java
@@ -74,11 +74,32 @@ public class JAtomInt implements IJExpression
       this.representer = representer;
     }
 
-    public String represent (int i)
+    public String represent (int i, int every, int sepSize)
     {
-      if (i < 0)
-        return "-" + represent (-i);
-      return prefix + representer.apply (i);
+      boolean neg = i < 0;
+      i = neg ? -i : i;
+      StringBuilder sb = new StringBuilder ();
+      if (neg)
+        sb.append ('-');
+      sb.append (prefix);
+      addSep (representer.apply (i), every, sepSize, sb);
+      return sb.toString ();
+    }
+
+    /// @param source unsigned non-prefixed representation , eg a5 for -0xa5 .
+    static void addSep(@NonNull String source, int every, int sepSize, StringBuilder sb) {
+      if (every < 1 || every >= source.length () || sepSize < 1)
+      {
+        sb.append (source);
+        return;
+      }
+      String sep = "_".repeat (sepSize);
+      for (int start = 0, end = source.length () % every; end <= source.length (); start = end, end += every)
+      {
+        if (start != 0)
+          sb.append (sep);
+        sb.append (source.substring (start, end));
+      }
     }
   }
 
@@ -124,9 +145,37 @@ public class JAtomInt implements IJExpression
     return m_nValue;
   }
 
+  /// how many underscores per separation
+  private int separatorSize = 1;
+
+  public int separatorSize ()
+  {
+    return separatorSize;
+  }
+
+  public JAtomInt separatorSize (int size)
+  {
+    this.separatorSize = size;
+    return this;
+  }
+
+  /// how many underscores per separation
+  private int separateEvery = 0;
+
+  public int separateEvery ()
+  {
+    return separateEvery;
+  }
+
+  public JAtomInt separateEvery (int every)
+  {
+    this.separateEvery = every;
+    return this;
+  }
+
   public void generate (@NonNull final IJFormatter f)
   {
-    f.print (representation.represent (m_nValue));
+    f.print (representation.represent (m_nValue, separateEvery, separatorSize));
   }
 
   @Override

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomInt.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomInt.java
@@ -96,7 +96,6 @@ public class JAtomInt implements IJExpression
   {
     if (representation != null)
       this.representation = representation;
-    int i = 07;
     return this;
   }
 

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
@@ -10,27 +10,30 @@ public class JAtomIntTest
   @Test
   public void testRepresentation ()
   {
+    // basic representation
     {
-      JAtomInt i42 = new JAtomInt (42);
+      JAtomInt i42 = new JAtomInt (42).separateEvery (0);
       Assert.assertEquals ("0b101010", CodeModelTestsHelper.toString (i42.binary ()));
       Assert.assertEquals ("42", CodeModelTestsHelper.toString (i42.decimal ()));
       Assert.assertEquals ("0x2a", CodeModelTestsHelper.toString (i42.hex ()));
       Assert.assertEquals ("052", CodeModelTestsHelper.toString (i42.octal ()));
     }
     {
-      JAtomInt i0 = new JAtomInt (0);
+      JAtomInt i0 = new JAtomInt (0).separateEvery (0);
       Assert.assertEquals ("0b0", CodeModelTestsHelper.toString (i0.binary ()));
       Assert.assertEquals ("0", CodeModelTestsHelper.toString (i0.decimal ()));
       Assert.assertEquals ("0x0", CodeModelTestsHelper.toString (i0.hex ()));
       Assert.assertEquals ("00", CodeModelTestsHelper.toString (i0.octal ()));
     }
     {
-      JAtomInt iNeg2 = new JAtomInt (-2);
+      JAtomInt iNeg2 = new JAtomInt (-2).separateEvery (0);
       Assert.assertEquals ("-0b10", CodeModelTestsHelper.toString (iNeg2.binary ()));
       Assert.assertEquals ("-2", CodeModelTestsHelper.toString (iNeg2.decimal ()));
       Assert.assertEquals ("-0x2", CodeModelTestsHelper.toString (iNeg2.hex ()));
       Assert.assertEquals ("-02", CodeModelTestsHelper.toString (iNeg2.octal ()));
     }
+
+    // separators
     {
       JAtomInt ia = new JAtomInt (-1234567).separatorSize (2).separateEvery (2).decimal ();
       Assert.assertEquals ("-1__23__45__67", CodeModelTestsHelper.toString (ia));

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
@@ -10,17 +10,32 @@ public class JAtomIntTest
   @Test
   public void testRepresentation ()
   {
-    JAtomInt i42 = new JAtomInt (42);
-    Assert.assertEquals ("0b101010", CodeModelTestsHelper.toString (i42.binary ()));
-    Assert.assertEquals ("42", CodeModelTestsHelper.toString (i42.decimal ()));
-    Assert.assertEquals ("0x2a", CodeModelTestsHelper.toString (i42.hex ()));
-    Assert.assertEquals ("052", CodeModelTestsHelper.toString (i42.octal ()));
-
-    JAtomInt iNeg2 = new JAtomInt (-2);
-    Assert.assertEquals ("-0b10", CodeModelTestsHelper.toString (iNeg2.binary ()));
-    Assert.assertEquals ("-2", CodeModelTestsHelper.toString (iNeg2.decimal ()));
-    Assert.assertEquals ("-0x2", CodeModelTestsHelper.toString (iNeg2.hex ()));
-    Assert.assertEquals ("-02", CodeModelTestsHelper.toString (iNeg2.octal ()));
+    {
+      JAtomInt i42 = new JAtomInt (42);
+      Assert.assertEquals ("0b101010", CodeModelTestsHelper.toString (i42.binary ()));
+      Assert.assertEquals ("42", CodeModelTestsHelper.toString (i42.decimal ()));
+      Assert.assertEquals ("0x2a", CodeModelTestsHelper.toString (i42.hex ()));
+      Assert.assertEquals ("052", CodeModelTestsHelper.toString (i42.octal ()));
+    }
+    {
+      JAtomInt iNeg2 = new JAtomInt (-2);
+      Assert.assertEquals ("-0b10", CodeModelTestsHelper.toString (iNeg2.binary ()));
+      Assert.assertEquals ("-2", CodeModelTestsHelper.toString (iNeg2.decimal ()));
+      Assert.assertEquals ("-0x2", CodeModelTestsHelper.toString (iNeg2.hex ()));
+      Assert.assertEquals ("-02", CodeModelTestsHelper.toString (iNeg2.octal ()));
+    }
+    {
+      JAtomInt ia = new JAtomInt (-1234567).separatorSize (2).separateEvery (2);
+      Assert.assertEquals ("-1__23__45__67", CodeModelTestsHelper.toString (ia.decimal ()));
+    }
+    {
+      JAtomInt ia = new JAtomInt (-12345678).separatorSize (2).separateEvery (2);
+      Assert.assertEquals ("-12__34__56__78", CodeModelTestsHelper.toString (ia.decimal ()));
+    }
+    {
+      JAtomInt ia = new JAtomInt (-10).separatorSize (1).separateEvery (3);
+      Assert.assertEquals ("-0b1_010", CodeModelTestsHelper.toString (ia.binary ()));
+    }
   }
 
 }

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
@@ -18,6 +18,13 @@ public class JAtomIntTest
       Assert.assertEquals ("052", CodeModelTestsHelper.toString (i42.octal ()));
     }
     {
+      JAtomInt i0 = new JAtomInt (0);
+      Assert.assertEquals ("0b0", CodeModelTestsHelper.toString (i0.binary ()));
+      Assert.assertEquals ("0", CodeModelTestsHelper.toString (i0.decimal ()));
+      Assert.assertEquals ("0x0", CodeModelTestsHelper.toString (i0.hex ()));
+      Assert.assertEquals ("00", CodeModelTestsHelper.toString (i0.octal ()));
+    }
+    {
       JAtomInt iNeg2 = new JAtomInt (-2);
       Assert.assertEquals ("-0b10", CodeModelTestsHelper.toString (iNeg2.binary ()));
       Assert.assertEquals ("-2", CodeModelTestsHelper.toString (iNeg2.decimal ()));
@@ -25,16 +32,24 @@ public class JAtomIntTest
       Assert.assertEquals ("-02", CodeModelTestsHelper.toString (iNeg2.octal ()));
     }
     {
-      JAtomInt ia = new JAtomInt (-1234567).separatorSize (2).separateEvery (2);
-      Assert.assertEquals ("-1__23__45__67", CodeModelTestsHelper.toString (ia.decimal ()));
+      JAtomInt ia = new JAtomInt (-1234567).separatorSize (2).separateEvery (2).decimal ();
+      Assert.assertEquals ("-1__23__45__67", CodeModelTestsHelper.toString (ia));
     }
     {
-      JAtomInt ia = new JAtomInt (-12345678).separatorSize (2).separateEvery (2);
-      Assert.assertEquals ("-12__34__56__78", CodeModelTestsHelper.toString (ia.decimal ()));
+      JAtomInt ia = new JAtomInt (-12345678).separatorSize (2).separateEvery (2).decimal ();
+      Assert.assertEquals ("-12__34__56__78", CodeModelTestsHelper.toString (ia));
     }
     {
-      JAtomInt ia = new JAtomInt (-10).separatorSize (1).separateEvery (3);
-      Assert.assertEquals ("-0b1_010", CodeModelTestsHelper.toString (ia.binary ()));
+      JAtomInt ia = new JAtomInt (-10).separatorSize (1).separateEvery (3).binary ();
+      Assert.assertEquals ("-0b1_010", CodeModelTestsHelper.toString (ia));
+    }
+    {
+      JAtomInt ia = new JAtomInt (4).separatorSize (1).separateEvery (3).binary ();
+      Assert.assertEquals ("0b100", CodeModelTestsHelper.toString (ia));
+    }
+    {
+      JAtomInt ia = new JAtomInt (8).separatorSize (1).separateEvery (3).binary ();
+      Assert.assertEquals ("0b1_000", CodeModelTestsHelper.toString (ia));
     }
   }
 

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
@@ -1,0 +1,26 @@
+package com.helger.jcodemodel;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.helger.jcodemodel.util.CodeModelTestsHelper;
+
+public class JAtomIntTest
+{
+  @Test
+  public void testRepresentation ()
+  {
+    JAtomInt i42 = new JAtomInt (42);
+    Assert.assertEquals ("0b101010", CodeModelTestsHelper.toString (i42.binary ()));
+    Assert.assertEquals ("42", CodeModelTestsHelper.toString (i42.decimal ()));
+    Assert.assertEquals ("0x2a", CodeModelTestsHelper.toString (i42.hex ()));
+    Assert.assertEquals ("052", CodeModelTestsHelper.toString (i42.octal ()));
+
+    JAtomInt iNeg2 = new JAtomInt (-2);
+    Assert.assertEquals ("-0b10", CodeModelTestsHelper.toString (iNeg2.binary ()));
+    Assert.assertEquals ("-2", CodeModelTestsHelper.toString (iNeg2.decimal ()));
+    Assert.assertEquals ("-0x2", CodeModelTestsHelper.toString (iNeg2.hex ()));
+    Assert.assertEquals ("-02", CodeModelTestsHelper.toString (iNeg2.octal ()));
+  }
+
+}

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/intformat/FormatIntWithSeparatorEvery0Size1.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/intformat/FormatIntWithSeparatorEvery0Size1.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.helger.jcodemodel.tests.intformat;
+
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
+public class FormatIntWithSeparatorEvery0Size1 {
+    public static final int i32b = 0b100000;
+    public static final int i32d = 32;
+    public static final int i32h = 0x20;
+    public static final int i32o = 040;
+    public static final int i1Mb = 0b100000000000000000000;
+    public static final int i1Md = 1048576;
+    public static final int i1Mh = 0x100000;
+    public static final int i1Mo = 04000000;
+    public static final int iNeg1kb = -0b10000000000;
+    public static final int iNeg1kd = -1024;
+    public static final int iNeg1kh = -0x400;
+    public static final int iNeg1ko = -02000;
+}

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/intformat/FormatIntWithSeparatorEvery2Size2.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/intformat/FormatIntWithSeparatorEvery2Size2.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.helger.jcodemodel.tests.intformat;
+
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
+public class FormatIntWithSeparatorEvery2Size2 {
+    public static final int i32b = 0b10__00__00;
+    public static final int i32d = 32;
+    public static final int i32h = 0x20;
+    public static final int i32o = 040;
+    public static final int i1Mb = 0b1__00__00__00__00__00__00__00__00__00__00;
+    public static final int i1Md = 1__04__85__76;
+    public static final int i1Mh = 0x10__00__00;
+    public static final int i1Mo = 04__00__00__00;
+    public static final int iNeg1kb = -0b1__00__00__00__00__00;
+    public static final int iNeg1kd = -10__24;
+    public static final int iNeg1kh = -0x4__00;
+    public static final int iNeg1ko = -020__00;
+}

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/intformat/FormatIntWithSeparatorEvery3Size1.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/intformat/FormatIntWithSeparatorEvery3Size1.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.helger.jcodemodel.tests.intformat;
+
+import javax.annotation.processing.Generated;
+
+@Generated("com.helger.jcodemodel.JCodeModel")
+public class FormatIntWithSeparatorEvery3Size1 {
+    public static final int i32b = 0b100_000;
+    public static final int i32d = 32;
+    public static final int i32h = 0x20;
+    public static final int i32o = 040;
+    public static final int i1Mb = 0b100_000_000_000_000_000_000;
+    public static final int i1Md = 1_048_576;
+    public static final int i1Mh = 0x100_000;
+    public static final int i1Mo = 04_000_000;
+    public static final int iNeg1kb = -0b10_000_000_000;
+    public static final int iNeg1kd = -1_024;
+    public static final int iNeg1kh = -0x400;
+    public static final int iNeg1ko = -02_000;
+}

--- a/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/intformat/IntFormatTestGen.java
+++ b/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/intformat/IntFormatTestGen.java
@@ -1,0 +1,53 @@
+package com.helger.jcodemodel.tests.intformat;
+
+import com.helger.jcodemodel.JDefinedClass;
+import com.helger.jcodemodel.JExpr;
+import com.helger.jcodemodel.JMod;
+import com.helger.jcodemodel.JPackage;
+import com.helger.jcodemodel.compile.annotation.TestJCM;
+import com.helger.jcodemodel.exceptions.JCodeModelException;
+
+@TestJCM
+public class IntFormatTestGen {
+
+  static void addFields(JDefinedClass clazz, int separateEvery, int sepSize) {
+    clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "i32b",
+        JExpr.lit(32).binary().separateEvery(separateEvery).separatorSize(sepSize));
+    clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "i32d",
+        JExpr.lit(32).decimal().separateEvery(separateEvery).separatorSize(sepSize));
+    clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "i32h",
+        JExpr.lit(32).hex().separateEvery(separateEvery).separatorSize(sepSize));
+    clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "i32o",
+        JExpr.lit(32).octal().separateEvery(separateEvery).separatorSize(sepSize));
+
+    clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "i1Mb",
+        JExpr.lit(1024 * 1024).binary().separateEvery(separateEvery).separatorSize(sepSize));
+    clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "i1Md",
+        JExpr.lit(1024 * 1024).decimal().separateEvery(separateEvery).separatorSize(sepSize));
+    clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "i1Mh",
+        JExpr.lit(1024 * 1024).hex().separateEvery(separateEvery).separatorSize(sepSize));
+    clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "i1Mo",
+        JExpr.lit(1024 * 1024).octal().separateEvery(separateEvery).separatorSize(sepSize));
+
+    clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "iNeg1kb",
+        JExpr.lit(-1024).binary().separateEvery(separateEvery).separatorSize(sepSize));
+    clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "iNeg1kd",
+        JExpr.lit(-1024).decimal().separateEvery(separateEvery).separatorSize(sepSize));
+    clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "iNeg1kh",
+        JExpr.lit(-1024).hex().separateEvery(separateEvery).separatorSize(sepSize));
+    clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "iNeg1ko",
+        JExpr.lit(-1024).octal().separateEvery(separateEvery).separatorSize(sepSize));
+  }
+
+  static void generate(JPackage root, int separateEvery, int sepSize) throws JCodeModelException {
+    JDefinedClass jdc = root._class("FormatIntWithSeparatorEvery" + separateEvery + "Size" + sepSize);
+    addFields(jdc, separateEvery, sepSize);
+  }
+
+  public void generateExamples(JPackage root) throws JCodeModelException {
+    generate(root, 0, 1);
+    generate(root, 3, 1);
+    generate(root, 2, 2);
+  }
+
+}


### PR DESCRIPTION
JAtomInt has new property representation to select output format.

Those are per-instance and not at writer level because some int may be written hex, other dec, in the same project or even class.

Added chaining assignment and tests