### PR TITLE
Integer representation specification

### DIFF
--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomInt.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomInt.java
@@ -114,7 +114,7 @@ public class JAtomInt implements IJExpression
     {
       if (qtty <= body.length ())
         return body;
-      return String.format ("%" + qtty + "s", body).replace (' ', '0');
+      return "0".repeat (qtty - body.length ()) + body;
     }
   }
 

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomInt.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomInt.java
@@ -58,7 +58,14 @@ public class JAtomInt implements IJExpression
   public static enum Representation
   {
     BINARY ("0b", Integer::toBinaryString),
-    DECIMAL ("", Integer::toString),
+    DECIMAL ("", Integer::toString)
+    {
+      @Override
+      protected String pad (@NonNull String body, int qtty)
+      {
+        return body;
+      }
+    },
     HEX ("0x", Integer::toHexString),
     OCTAL ("0", Integer::toOctalString);
 
@@ -74,7 +81,7 @@ public class JAtomInt implements IJExpression
       this.representer = representer;
     }
 
-    public String represent (int i, int every, int sepSize)
+    public String represent (int i, int sepEvery, int sepSize, int padding)
     {
       boolean neg = i < 0;
       i = neg ? -i : i;
@@ -82,24 +89,32 @@ public class JAtomInt implements IJExpression
       if (neg)
         sb.append ('-');
       sb.append (prefix);
-      addSep (representer.apply (i), every, sepSize, sb);
+      addSep (pad (representer.apply (i), padding), sepEvery, sepSize, sb);
       return sb.toString ();
     }
 
     /// @param source unsigned non-prefixed representation , eg a5 for -0xa5 .
-    static void addSep(@NonNull String source, int every, int sepSize, StringBuilder sb) {
-      if (every < 1 || every >= source.length () || sepSize < 1)
+    static void addSep (@NonNull String source, int sepEvery, int sepSize, StringBuilder sb)
+    {
+      if (sepEvery < 1 || sepEvery >= source.length () || sepSize < 1)
       {
         sb.append (source);
         return;
       }
       String sep = "_".repeat (sepSize);
-      for (int start = 0, end = source.length () % every; end <= source.length (); start = end, end += every)
+      for (int start = 0, end = source.length () % sepEvery; end <= source.length (); start = end, end += sepEvery)
       {
         if (start != 0)
           sb.append (sep);
         sb.append (source.substring (start, end));
       }
+    }
+
+    protected String pad (@NonNull String body, int qtty)
+    {
+      if (qtty <= body.length ())
+        return body;
+      return String.format ("%" + qtty + "s", body).replace (' ', '0');
     }
   }
 
@@ -159,7 +174,7 @@ public class JAtomInt implements IJExpression
     return this;
   }
 
-  /// how many underscores per separation
+  /// how many character before underscore separation
   private int separateEvery = 0;
 
   public int separateEvery ()
@@ -173,9 +188,25 @@ public class JAtomInt implements IJExpression
     return this;
   }
 
+  /// how many character minimum must the body have. ignored for decimal representation.
+  ///
+  /// for example, the binary representation for 0 with padding 4 is 0b0000 .
+  private int padding = 0;
+
+  public int padding ()
+  {
+    return padding;
+  }
+
+  public JAtomInt padding (int padding)
+  {
+    this.padding = padding;
+    return this;
+  }
+
   public void generate (@NonNull final IJFormatter f)
   {
-    f.print (representation.represent (m_nValue, separateEvery, separatorSize));
+    f.print (representation.represent (m_nValue, separateEvery, separatorSize, padding));
   }
 
   @Override

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomInt.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomInt.java
@@ -46,6 +46,7 @@ import org.jspecify.annotations.NonNull;
 
 import com.helger.base.equals.EqualsHelper;
 import com.helger.jcodemodel.literals.AIntegerRepresented;
+import com.helger.jcodemodel.literals.IntegerRepresentation;
 
 /**
  * A special atom for int values
@@ -58,6 +59,12 @@ public class JAtomInt extends AIntegerRepresented <JAtomInt> implements IJExpres
   protected JAtomInt (final int nWhat)
   {
     m_nValue = nWhat;
+  }
+
+  protected JAtomInt (final int nWhat, IntegerRepresentation representation)
+  {
+    m_nValue = nWhat;
+    representation (representation);
   }
 
   public int what ()

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomInt.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomInt.java
@@ -42,117 +42,22 @@ package com.helger.jcodemodel;
 
 import static com.helger.jcodemodel.util.JCHashCodeGenerator.getHashCode;
 
-import java.util.function.IntFunction;
-
 import org.jspecify.annotations.NonNull;
 
 import com.helger.base.equals.EqualsHelper;
+import com.helger.jcodemodel.literals.AIntegerRepresented;
 
 /**
  * A special atom for int values
  */
-public class JAtomInt implements IJExpression
+public class JAtomInt extends AIntegerRepresented <JAtomInt> implements IJExpression
 {
 
-  /// @see https://docs.oracle.com/javase/specs/jls/se17/html/jls-3.html#jls-3.10.1
-  public static enum Representation
-  {
-    BINARY ("0b", Integer::toBinaryString),
-    DECIMAL ("", Integer::toString)
-    {
-      @Override
-      protected String pad (@NonNull String body, int qtty)
-      {
-        return body;
-      }
-    },
-    HEX ("0x", Integer::toHexString),
-    OCTAL ("0", Integer::toOctalString);
-
-    @NonNull
-    final IntFunction <String> representer;
-
-    @NonNull
-    final String prefix;
-
-    Representation (String prefix, IntFunction <String> representer)
-    {
-      this.prefix = prefix;
-      this.representer = representer;
-    }
-
-    public String represent (int i, int sepEvery, int sepSize, int padding)
-    {
-      boolean neg = i < 0;
-      i = neg ? -i : i;
-      StringBuilder sb = new StringBuilder ();
-      if (neg)
-        sb.append ('-');
-      sb.append (prefix);
-      addSep (pad (representer.apply (i), padding), sepEvery, sepSize, sb);
-      return sb.toString ();
-    }
-
-    /// @param source unsigned non-prefixed representation , eg a5 for -0xa5 .
-    static void addSep (@NonNull String source, int sepEvery, int sepSize, StringBuilder sb)
-    {
-      if (sepEvery < 1 || sepEvery >= source.length () || sepSize < 1)
-      {
-        sb.append (source);
-        return;
-      }
-      String sep = "_".repeat (sepSize);
-      for (int start = 0, end = source.length () % sepEvery; end <= source.length (); start = end, end += sepEvery)
-      {
-        if (start != 0)
-          sb.append (sep);
-        sb.append (source.substring (start, end));
-      }
-    }
-
-    protected String pad (@NonNull String body, int qtty)
-    {
-      if (qtty <= body.length ())
-        return body;
-      return "0".repeat (qtty - body.length ()) + body;
-    }
-  }
-
   private final int m_nValue;
-
-  @NonNull
-  private Representation representation = Representation.DECIMAL;
 
   protected JAtomInt (final int nWhat)
   {
     m_nValue = nWhat;
-  }
-
-  public JAtomInt representation (Representation representation)
-  {
-    if (representation != null)
-      this.representation = representation;
-    return this;
-  }
-
-  public JAtomInt binary ()
-  {
-    return representation (Representation.BINARY);
-  }
-
-  public JAtomInt decimal ()
-  {
-    return representation (Representation.DECIMAL);
-  }
-
-  public JAtomInt hex ()
-  {
-    return representation (Representation.HEX);
-  }
-
-  public JAtomInt octal ()
-  {
-    return representation (Representation.OCTAL);
   }
 
   public int what ()
@@ -160,53 +65,9 @@ public class JAtomInt implements IJExpression
     return m_nValue;
   }
 
-  /// how many underscores per separation
-  private int separatorSize = 1;
-
-  public int separatorSize ()
-  {
-    return separatorSize;
-  }
-
-  public JAtomInt separatorSize (int size)
-  {
-    this.separatorSize = size;
-    return this;
-  }
-
-  /// how many character before underscore separation
-  private int separateEvery = 0;
-
-  public int separateEvery ()
-  {
-    return separateEvery;
-  }
-
-  public JAtomInt separateEvery (int every)
-  {
-    this.separateEvery = every;
-    return this;
-  }
-
-  /// how many character minimum must the body have. ignored for decimal representation.
-  ///
-  /// for example, the binary representation for 0 with padding 4 is 0b0000 .
-  private int padding = 0;
-
-  public int padding ()
-  {
-    return padding;
-  }
-
-  public JAtomInt padding (int padding)
-  {
-    this.padding = padding;
-    return this;
-  }
-
   public void generate (@NonNull final IJFormatter f)
   {
-    f.print (representation.represent (m_nValue, separateEvery, separatorSize, padding));
+    f.print (representation.format (m_nValue));
   }
 
   @Override

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomLong.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomLong.java
@@ -45,13 +45,13 @@ import static com.helger.jcodemodel.util.JCHashCodeGenerator.getHashCode;
 import org.jspecify.annotations.NonNull;
 
 import com.helger.base.equals.EqualsHelper;
+import com.helger.jcodemodel.literals.AIntegerRepresented;
 
 /**
  * A special atom for long values
  */
-public class JAtomLong implements IJExpression
+public class JAtomLong extends AIntegerRepresented <JAtomLong> implements IJExpression
 {
-  public static final String SUFFIX_LONG = "L";
 
   private final long m_nValue;
 
@@ -67,7 +67,7 @@ public class JAtomLong implements IJExpression
 
   public void generate (@NonNull final IJFormatter f)
   {
-    f.print (Long.toString (m_nValue) + SUFFIX_LONG);
+    f.print (representation.format (m_nValue));
   }
 
   @Override

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomLong.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomLong.java
@@ -46,6 +46,7 @@ import org.jspecify.annotations.NonNull;
 
 import com.helger.base.equals.EqualsHelper;
 import com.helger.jcodemodel.literals.AIntegerRepresented;
+import com.helger.jcodemodel.literals.IntegerRepresentation;
 
 /**
  * A special atom for long values
@@ -58,6 +59,12 @@ public class JAtomLong extends AIntegerRepresented <JAtomLong> implements IJExpr
   protected JAtomLong (final long nWhat)
   {
     m_nValue = nWhat;
+  }
+
+  public JAtomLong (final long nWhat, IntegerRepresentation representation)
+  {
+    m_nValue = nWhat;
+    representation (representation);
   }
 
   public long what ()

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/AIntegerRepresented.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/AIntegerRepresented.java
@@ -1,0 +1,98 @@
+package com.helger.jcodemodel.literals;
+
+/// Something that has an IntegerRepresentation to update.
+/// 
+/// Its abstract because it's just a tooling class to extend.
+/// 
+/// @param T must be declaring class, eg `class A extends AIntegerRepresented<A>`
+public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
+{
+
+  protected IntegerRepresentation representation = IntegerRepresentation.DEFAULT;
+
+  @SuppressWarnings ("unchecked")
+  protected T self ()
+  {
+    return (T) this;
+  }
+
+  public IntegerRepresentation representation ()
+  {
+    return representation;
+  }
+
+  /// change the internal representation to the provided one
+  ///
+  /// @return this
+  /// @see [IntegerRepresentation] for the meaning of individual fields
+  public T representation (IntegerRepresentation representation)
+  {
+    if (representation != null)
+      this.representation = representation;
+    return self ();
+  }
+
+  /// change the internal representation to match the request
+  ///
+  /// @return this
+  /// @see [IntegerRepresentation] for the meaning of individual fields
+  public T binary ()
+  {
+    return representation (representation.base (IntegerBase.BINARY));
+  }
+
+  /// change the internal representation to match the request
+  ///
+  /// @return this
+  /// @see [IntegerRepresentation] for the meaning of individual fields
+  public T decimal ()
+  {
+    return representation (representation.base (IntegerBase.DECIMAL));
+  }
+
+  /// change the internal representation to match the request
+  ///
+  /// @return this
+  /// @see [IntegerRepresentation] for the meaning of individual fields
+  public T hex ()
+  {
+    return representation (representation.base (IntegerBase.HEX));
+  }
+
+  /// change the internal representation to match the request
+  ///
+  /// @return this
+  /// @see [IntegerRepresentation] for the meaning of individual fields
+  public T octal ()
+  {
+    return representation (representation.base (IntegerBase.OCTAL));
+  }
+
+  /// change the internal representation to match the request
+  ///
+  /// @return this
+  /// @see [IntegerRepresentation] for the meaning of individual fields
+  public T separatorSize (int size)
+  {
+    return representation (representation.separatorSize (size));
+  }
+
+  /// change the internal representation to match the request
+  ///
+  /// @return this
+  /// @see [IntegerRepresentation] for the meaning of individual fields
+  public T separateEvery (int every)
+  {
+    return representation (representation.separateEvery (every));
+  }
+
+  /// change the internal representation to match the request
+  ///
+  /// @return this
+  /// @see [IntegerRepresentation] for the meaning of individual fields
+  public T padding (int padding)
+  {
+    return representation (representation.padding (padding));
+  }
+
+}

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/AIntegerRepresented.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/AIntegerRepresented.java
@@ -63,7 +63,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   ///
   /// @return this
   /// @see [IntegerRepresentation] for the meaning of individual fields
-  public T hex ()
+  public T hexadecimal ()
   {
     return representation (representation.base (EIntegerBase.HEXADECIMAL));
   }

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/AIntegerRepresented.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/AIntegerRepresented.java
@@ -1,6 +1,8 @@
 package com.helger.jcodemodel.literals;
 
-/// Something that has an IntegerRepresentation to update.
+import org.jspecify.annotations.NonNull;
+
+/// Something that has an IntegerRepresentation to update, in practice only JAtomInt and JAtomLong
 /// 
 /// Its abstract because it's just a tooling class to extend.
 /// 
@@ -8,6 +10,7 @@ package com.helger.jcodemodel.literals;
 public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
 {
 
+  @NonNull
   protected IntegerRepresentation representation = IntegerRepresentation.DEFAULT;
 
   @SuppressWarnings ("unchecked")
@@ -24,7 +27,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// change the internal representation to the provided one
   ///
   /// @return this
-  /// @see [IntegerRepresentation] for the meaning of individual fields
+  /// @param representation if null, nothing changes.
   public T representation (IntegerRepresentation representation)
   {
     if (representation != null)
@@ -32,73 +35,70 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
     return self ();
   }
 
-  /// change the internal representation to match the request
+  /// change the internal representation to show positive sign
   ///
   /// @return this
-  /// @see [IntegerRepresentation] for the meaning of individual fields
   public T positiveSign (boolean positiveSign)
   {
     return representation (representation.positiveSign (positiveSign));
   }
 
-  /// change the internal representation to match the request
+  /// change the internal representation to use binary base
   ///
   /// @return this
-  /// @see [IntegerRepresentation] for the meaning of individual fields
   public T binary ()
   {
     return representation (representation.base (EIntegerBase.BINARY));
   }
 
-  /// change the internal representation to match the request
+  /// change the internal representation to use decimal base
   ///
   /// @return this
-  /// @see [IntegerRepresentation] for the meaning of individual fields
   public T decimal ()
   {
     return representation (representation.base (EIntegerBase.DECIMAL));
   }
 
-  /// change the internal representation to match the request
+  /// change the internal representation to use hexadecimal base
   ///
   /// @return this
-  /// @see [IntegerRepresentation] for the meaning of individual fields
   public T hexadecimal ()
   {
     return representation (representation.base (EIntegerBase.HEXADECIMAL));
   }
 
-  /// change the internal representation to match the request
+  /// change the internal representation to use octal base
   ///
   /// @return this
-  /// @see [IntegerRepresentation] for the meaning of individual fields
   public T octal ()
   {
     return representation (representation.base (EIntegerBase.OCTAL));
   }
 
-  /// change the internal representation to match the request
+  /// change the internal representation to use a fixed separator size (the number of character
+  /// BETWEEN
+  /// each separated group), used only when **NO** separator format is provided
   ///
   /// @return this
-  /// @see [IntegerRepresentation] for the meaning of individual fields
   public T separatorSize (int size)
   {
     return representation (representation.separatorSize (size));
   }
 
-  /// change the internal representation to match the request
+  /// change the internal representation to use a fixed separator distance (the maximum number of
+  /// character IN
+  /// a separated group), used only when **NO** separator format is provided
   ///
   /// @return this
-  /// @see [IntegerRepresentation] for the meaning of individual fields
   public T separateEvery (int every)
   {
     return representation (representation.separateEvery (every));
   }
 
-  /// change the internal representation to match the request
+  /// change the internal representation to use a padding value. The padding is not used for decimal
+  /// base, since leading "0" makes an octal.
   ///
   /// @return this
-  /// @see [IntegerRepresentation] for the meaning of individual fields
   public T padding (int padding)
   {
     return representation (representation.padding (padding));

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/AIntegerRepresented.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/AIntegerRepresented.java
@@ -65,7 +65,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// @see [IntegerRepresentation] for the meaning of individual fields
   public T hex ()
   {
-    return representation (representation.base (EIntegerBase.HEX));
+    return representation (representation.base (EIntegerBase.HEXADECIMAL));
   }
 
   /// change the internal representation to match the request

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/AIntegerRepresented.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/AIntegerRepresented.java
@@ -38,7 +38,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// @see [IntegerRepresentation] for the meaning of individual fields
   public T binary ()
   {
-    return representation (representation.base (IntegerBase.BINARY));
+    return representation (representation.base (EIntegerBase.BINARY));
   }
 
   /// change the internal representation to match the request
@@ -47,7 +47,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// @see [IntegerRepresentation] for the meaning of individual fields
   public T decimal ()
   {
-    return representation (representation.base (IntegerBase.DECIMAL));
+    return representation (representation.base (EIntegerBase.DECIMAL));
   }
 
   /// change the internal representation to match the request
@@ -56,7 +56,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// @see [IntegerRepresentation] for the meaning of individual fields
   public T hex ()
   {
-    return representation (representation.base (IntegerBase.HEX));
+    return representation (representation.base (EIntegerBase.HEX));
   }
 
   /// change the internal representation to match the request
@@ -65,7 +65,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// @see [IntegerRepresentation] for the meaning of individual fields
   public T octal ()
   {
-    return representation (representation.base (IntegerBase.OCTAL));
+    return representation (representation.base (EIntegerBase.OCTAL));
   }
 
   /// change the internal representation to match the request

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/AIntegerRepresented.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/AIntegerRepresented.java
@@ -36,6 +36,15 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   ///
   /// @return this
   /// @see [IntegerRepresentation] for the meaning of individual fields
+  public T positiveSign (boolean positiveSign)
+  {
+    return representation (representation.positiveSign (positiveSign));
+  }
+
+  /// change the internal representation to match the request
+  ///
+  /// @return this
+  /// @see [IntegerRepresentation] for the meaning of individual fields
   public T binary ()
   {
     return representation (representation.base (EIntegerBase.BINARY));

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/AIntegerRepresented.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/AIntegerRepresented.java
@@ -19,6 +19,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
     return (T) this;
   }
 
+  @NonNull
   public IntegerRepresentation representation ()
   {
     return representation;
@@ -28,7 +29,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   ///
   /// @return this
   /// @param representation if null, nothing changes.
-  public T representation (IntegerRepresentation representation)
+  public @NonNull T representation (IntegerRepresentation representation)
   {
     if (representation != null)
       this.representation = representation;
@@ -38,7 +39,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// change the internal representation to show positive sign
   ///
   /// @return this
-  public T positiveSign (boolean positiveSign)
+  public @NonNull T positiveSign (boolean positiveSign)
   {
     return representation (representation.positiveSign (positiveSign));
   }
@@ -46,7 +47,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// change the internal representation to use binary base
   ///
   /// @return this
-  public T binary ()
+  public @NonNull T binary ()
   {
     return representation (representation.base (EIntegerBase.BINARY));
   }
@@ -54,7 +55,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// change the internal representation to use decimal base
   ///
   /// @return this
-  public T decimal ()
+  public @NonNull T decimal ()
   {
     return representation (representation.base (EIntegerBase.DECIMAL));
   }
@@ -62,7 +63,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// change the internal representation to use hexadecimal base
   ///
   /// @return this
-  public T hexadecimal ()
+  public @NonNull T hexadecimal ()
   {
     return representation (representation.base (EIntegerBase.HEXADECIMAL));
   }
@@ -70,7 +71,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// change the internal representation to use octal base
   ///
   /// @return this
-  public T octal ()
+  public @NonNull T octal ()
   {
     return representation (representation.base (EIntegerBase.OCTAL));
   }
@@ -80,7 +81,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// each separated group), used only when **NO** separator format is provided
   ///
   /// @return this
-  public T separatorSize (int size)
+  public @NonNull T separatorSize (int size)
   {
     return representation (representation.separatorSize (size));
   }
@@ -90,7 +91,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// a separated group), used only when **NO** separator format is provided
   ///
   /// @return this
-  public T separateEvery (int every)
+  public @NonNull T separateEvery (int every)
   {
     return representation (representation.separateEvery (every));
   }
@@ -99,7 +100,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// base, since leading "0" makes an octal.
   ///
   /// @return this
-  public T padding (int padding)
+  public @NonNull T padding (int padding)
   {
     return representation (representation.padding (padding));
   }

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/EIntegerBase.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/EIntegerBase.java
@@ -22,7 +22,7 @@ public enum EIntegerBase
       return body;
     }
   },
-  HEX ("0x", Integer::toHexString, Long::toHexString),
+  HEXADECIMAL ("0x", Integer::toHexString, Long::toHexString),
   OCTAL ("0", Integer::toOctalString, Long::toOctalString);
 
   @NonNull

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/EIntegerBase.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/EIntegerBase.java
@@ -11,7 +11,7 @@ import org.jspecify.annotations.NonNull;
 /// Those also contain the way to apply parameters when representing, in the corresponding represent methods 
 ///
 /// @see https://docs.oracle.com/javase/specs/jls/se17/html/jls-3.html#jls-3.10.1
-public enum IntegerBase
+public enum EIntegerBase
 {
   BINARY ("0b", Integer::toBinaryString, Long::toBinaryString),
   DECIMAL ("", Integer::toString, Long::toString)
@@ -36,7 +36,7 @@ public enum IntegerBase
   @NonNull
   final String prefixUpperCased;
 
-  IntegerBase (String prefix, IntFunction <String> intFormat, LongFunction <String> longFormat)
+  EIntegerBase (String prefix, IntFunction <String> intFormat, LongFunction <String> longFormat)
   {
     this.prefixLowerCased = prefix.toLowerCase (Locale.ROOT);
     this.prefixUpperCased = prefix.toUpperCase (Locale.ROOT);
@@ -44,6 +44,7 @@ public enum IntegerBase
     this.longFormat = longFormat;
   }
 
+  /// @return sb
   public StringBuilder represent (int i, StringBuilder sb, boolean prefixUpper, int padding, int sepEvery, int sepSize)
   {
     boolean neg = i < 0;
@@ -55,6 +56,7 @@ public enum IntegerBase
     return sb;
   }
 
+  /// @return sb
   public StringBuilder represent (long l, StringBuilder sb, boolean prefixUpper, int padding, int sepEvery, int sepSize, boolean suffixUpper)
   {
     boolean neg = l < 0;

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/EIntegerBase.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/EIntegerBase.java
@@ -66,14 +66,14 @@ public enum EIntegerBase
                                   IntegerRepresentation f)
   {
     boolean neg = i < 0;
-    i = neg ? -i : i;
+    int posI = neg ? -i : i;
     if (neg)
       sb.append ('-');
     else
       if (f.positiveSign ())
         sb.append ('+');
     sb.append (f.prefixUpper () ? prefixUpperCased : prefixLowerCased);
-    addSep (padBody (caseBody (intFormat.apply (i), f.bodyUpper ()), f.padding ()),
+    addSep (padBody (caseBody (intFormat.apply (posI), f.bodyUpper ()), f.padding ()),
             f.separateFormat (),
             allowBodyLeadingSep,
             f.separateEvery (),
@@ -88,14 +88,14 @@ public enum EIntegerBase
                                   IntegerRepresentation f)
   {
     boolean neg = l < 0;
-    l = neg ? -l : l;
+    long posL = neg ? -l : l;
     if (neg)
       sb.append ('-');
     else
       if (f.positiveSign ())
         sb.append ('+');
     sb.append (f.prefixUpper () ? prefixUpperCased : prefixLowerCased);
-    addSep (padBody (caseBody (longFormat.apply (l), f.bodyUpper ()), f.padding ()),
+    addSep (padBody (caseBody (longFormat.apply (posL), f.bodyUpper ()), f.padding ()),
             f.separateFormat (),
             allowBodyLeadingSep,
             f.separateEvery (),

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/EIntegerBase.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/EIntegerBase.java
@@ -14,10 +14,10 @@ import org.jspecify.annotations.Nullable;
 /// @see https://docs.oracle.com/javase/specs/jls/se17/html/jls-3.html#jls-3.10.1
 public enum EIntegerBase
 {
-  BINARY ("0b", Integer::toBinaryString, Long::toBinaryString, true, false),
-  DECIMAL ("", Integer::toString, Long::toString, false, false),
-  HEXADECIMAL ("0x", Integer::toHexString, Long::toHexString, true, false),
-  OCTAL ("0", Integer::toOctalString, Long::toOctalString, true, true);
+  BINARY ("0b", Integer::toBinaryString, Long::toBinaryString, false, true, false),
+  DECIMAL ("", Integer::toString, Long::toString, false, false, false),
+  HEXADECIMAL ("0x", Integer::toHexString, Long::toHexString, true, true, false),
+  OCTAL ("0", Integer::toOctalString, Long::toOctalString, false, true, true);
 
   @NonNull
   final IntFunction <String> intFormat;
@@ -34,8 +34,11 @@ public enum EIntegerBase
   final String prefixUpperCased;
 
   /// when true, the base allows padding. Only decimal does not allow padding, as a non-single
-  /// leading 0 means base octal.
+  /// leading 0 digit means base octal.
   final boolean enablePadding;
+
+  /// when true (only hex), this base can produce different uppercase and lowercase body.
+  final boolean enableBodyUpper;
 
   /// when true, the separator format can produce leading separators in the body ; when false, the
   /// body will always start with a base char.
@@ -44,6 +47,7 @@ public enum EIntegerBase
   EIntegerBase (String prefix,
                 IntFunction <String> intFormat,
                 LongFunction <String> longFormat,
+                boolean enableBodyUpper,
                 boolean enablePadding,
                 boolean allowBodyLeadingSep)
   {
@@ -51,6 +55,7 @@ public enum EIntegerBase
     this.prefixUpperCased = prefix.toUpperCase (Locale.ROOT);
     this.intFormat = intFormat;
     this.longFormat = longFormat;
+    this.enableBodyUpper = enableBodyUpper;
     this.enablePadding = enablePadding;
     this.allowBodyLeadingSep = allowBodyLeadingSep;
   }
@@ -60,6 +65,7 @@ public enum EIntegerBase
                                   StringBuilder sb,
                                   boolean positiveSign,
                                   boolean prefixUpper,
+                                  boolean bodyUpper,
                                   int padding,
                                   String sepFormat,
                                   int sepEvery,
@@ -73,7 +79,12 @@ public enum EIntegerBase
       if (positiveSign)
         sb.append ('+');
     sb.append (prefixUpper ? prefixUpperCased : prefixLowerCased);
-    addSep (padBody (intFormat.apply (i), padding), sepFormat, allowBodyLeadingSep, sepEvery, sepSize, sb);
+    addSep (padBody (caseBody (intFormat.apply (i), bodyUpper), padding),
+            sepFormat,
+            allowBodyLeadingSep,
+            sepEvery,
+            sepSize,
+            sb);
     return sb;
   }
 
@@ -82,6 +93,7 @@ public enum EIntegerBase
                                   StringBuilder sb,
                                   boolean positiveSign,
                                   boolean prefixUpper,
+                                  boolean bodyUpper,
                                   int padding,
                                   String sepFormat,
                                   int sepEvery,
@@ -96,9 +108,33 @@ public enum EIntegerBase
       if (positiveSign)
         sb.append ('+');
     sb.append (prefixUpper ? prefixUpperCased : prefixLowerCased);
-    addSep (padBody (longFormat.apply (l), padding), sepFormat, allowBodyLeadingSep, sepEvery, sepSize, sb);
+    addSep (padBody (caseBody (longFormat.apply (l), bodyUpper), padding),
+            sepFormat,
+            allowBodyLeadingSep,
+            sepEvery,
+            sepSize,
+            sb);
     sb.append (suffixUpper ? 'L' : 'l');
     return sb;
+  }
+
+  /// if the base differentiates upper and lower body, put it in the corresponding case.
+  protected @NonNull String caseBody (@NonNull String body, boolean upper)
+  {
+    if (enableBodyUpper)
+      return upper ? body.toUpperCase (Locale.ROOT) : body.toLowerCase (Locale.ROOT);
+    return body;
+  }
+
+  private static final char PAD_CHAR = '0';
+  private static final String PAD_STRING = String.valueOf (PAD_CHAR);
+
+  /// if the base is padding enabled (so not decimal), prefix the body to match given length
+  protected @NonNull String padBody (@NonNull String body, int qtty)
+  {
+    if (!enablePadding || qtty <= body.length ())
+      return body;
+    return PAD_STRING.repeat (qtty - body.length ()) + body;
   }
 
   private static final char SEP_CHAR = '_';
@@ -199,21 +235,5 @@ public enum EIntegerBase
         sb.append (source.substring (start, end));
       }
     }
-  }
-
-  private static final char PAD_CHAR = '0';
-  private static final String PAD_STRING = String.valueOf (PAD_CHAR);
-
-  /// only for bases with padding enabled (so not decimal)
-  protected String padBody (@NonNull String body, int qtty)
-  {
-    if (!enablePadding || qtty <= body.length ())
-      return body;
-    return PAD_STRING.repeat (qtty - body.length ()) + body;
-  }
-
-  protected String trimSeparators (@NonNull String body)
-  {
-    return body;
   }
 }

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/EIntegerBase.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/EIntegerBase.java
@@ -5,6 +5,7 @@ import java.util.function.IntFunction;
 import java.util.function.LongFunction;
 
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /// base to represent an int/long in.
 /// 
@@ -13,17 +14,10 @@ import org.jspecify.annotations.NonNull;
 /// @see https://docs.oracle.com/javase/specs/jls/se17/html/jls-3.html#jls-3.10.1
 public enum EIntegerBase
 {
-  BINARY ("0b", Integer::toBinaryString, Long::toBinaryString),
-  DECIMAL ("", Integer::toString, Long::toString)
-  {
-    @Override
-    protected String pad (@NonNull String body, int qtty)
-    {
-      return body;
-    }
-  },
-  HEXADECIMAL ("0x", Integer::toHexString, Long::toHexString),
-  OCTAL ("0", Integer::toOctalString, Long::toOctalString);
+  BINARY ("0b", Integer::toBinaryString, Long::toBinaryString, true, false),
+  DECIMAL ("", Integer::toString, Long::toString, false, false),
+  HEXADECIMAL ("0x", Integer::toHexString, Long::toHexString, true, false),
+  OCTAL ("0", Integer::toOctalString, Long::toOctalString, true, true);
 
   @NonNull
   final IntFunction <String> intFormat;
@@ -31,17 +25,34 @@ public enum EIntegerBase
   @NonNull
   final LongFunction <String> longFormat;
 
+  /// the lower-case base prefix. Only hex and bin have prefix case diff.
   @NonNull
   final String prefixLowerCased;
+
+  /// the upper-case base prefix. Only hex and bin have prefix case diff.
   @NonNull
   final String prefixUpperCased;
 
-  EIntegerBase (String prefix, IntFunction <String> intFormat, LongFunction <String> longFormat)
+  /// when true, the base allows padding. Only decimal does not allow padding, as a non-single
+  /// leading 0 means base octal.
+  final boolean enablePadding;
+
+  /// when true, the separator format can produce leading separators in the body ; when false, the
+  /// body will always start with a base char.
+  final boolean allowBodyLeadingSep;
+
+  EIntegerBase (String prefix,
+                IntFunction <String> intFormat,
+                LongFunction <String> longFormat,
+                boolean enablePadding,
+                boolean allowBodyLeadingSep)
   {
     this.prefixLowerCased = prefix.toLowerCase (Locale.ROOT);
     this.prefixUpperCased = prefix.toUpperCase (Locale.ROOT);
     this.intFormat = intFormat;
     this.longFormat = longFormat;
+    this.enablePadding = enablePadding;
+    this.allowBodyLeadingSep = allowBodyLeadingSep;
   }
 
   /// @return sb
@@ -50,6 +61,7 @@ public enum EIntegerBase
                                   boolean positiveSign,
                                   boolean prefixUpper,
                                   int padding,
+                                  String sepFormat,
                                   int sepEvery,
                                   int sepSize)
   {
@@ -61,7 +73,7 @@ public enum EIntegerBase
       if (positiveSign)
         sb.append ('+');
     sb.append (prefixUpper ? prefixUpperCased : prefixLowerCased);
-    addSep (pad (intFormat.apply (i), padding), sepEvery, sepSize, sb);
+    addSep (padBody (intFormat.apply (i), padding), sepFormat, allowBodyLeadingSep, sepEvery, sepSize, sb);
     return sb;
   }
 
@@ -71,6 +83,7 @@ public enum EIntegerBase
                                   boolean positiveSign,
                                   boolean prefixUpper,
                                   int padding,
+                                  String sepFormat,
                                   int sepEvery,
                                   int sepSize,
                                   boolean suffixUpper)
@@ -83,32 +96,124 @@ public enum EIntegerBase
       if (positiveSign)
         sb.append ('+');
     sb.append (prefixUpper ? prefixUpperCased : prefixLowerCased);
-    addSep (pad (longFormat.apply (l), padding), sepEvery, sepSize, sb);
+    addSep (padBody (longFormat.apply (l), padding), sepFormat, allowBodyLeadingSep, sepEvery, sepSize, sb);
     sb.append (suffixUpper ? 'L' : 'l');
     return sb;
   }
 
-  /// @param source unsigned non-prefixed representation , eg a5 for -0xa5 .
-  static void addSep (@NonNull String source, int sepEvery, int sepSize, StringBuilder sb)
+  private static final char SEP_CHAR = '_';
+  private static final String SEP_STRING = String.valueOf (SEP_CHAR);
+
+  /// Append a source with inserted separators into a stringbuilder.
+  ///
+  ///
+  /// ## Separator format
+  ///
+  /// The separator format is applied when non null ; otherwise, the sepEvery and sepSize are used.
+  ///
+  /// Each '_' in it specifies before which char (from the end) and in which quantity to insert
+  /// separator ( '_' ) ; other chars mean to copy from source. Last char is always assumed to be
+  /// non-separator, as terminating sep is not allowed in the body.
+  ///
+  /// For example, a format "c__l" means to insert 2 underscore before the last char, denoted with
+  /// 'l'. In that example, the 'c' character is useless so this is functionally the same as "__l",
+  /// or "cc__a".
+  ///
+  /// The format "__" means to insert a single sep before the last char. This is because the last
+  /// format char is always assumed to be non-sep ; so this is functionally the same as "_X"
+  ///
+  /// ## Separate every, size
+  ///
+  /// When the format is null and both sepEvery and sepSize are >0 , series of *sepSize* separators
+  /// are inserted every *sepEvery* character of source, starting from the end.
+  ///
+  /// @param source unsigned non-prefixed body representation , eg a5 for -0xa5L . If empty, nothing
+  /// is done (should never be called)
+  /// @param sepFormat separator format.
+  /// @param allowLeadingSep when true, allow to insert separator before the first source char. When
+  /// false, the first added char should be the one in source.
+  static void addSep (@NonNull String source,
+                      @Nullable String sepFormat,
+                      boolean allowLeadingSep,
+                      int sepEvery,
+                      int sepSize,
+                      @NonNull StringBuilder sb)
   {
-    if (sepEvery < 1 || sepEvery >= source.length () || sepSize < 1)
-    {
-      sb.append (source);
+    if (source.isEmpty ())
       return;
-    }
-    String sep = "_".repeat (sepSize);
-    for (int start = 0, end = source.length () % sepEvery; end <= source.length (); start = end, end += sepEvery)
+    if (sepFormat != null)
     {
-      if (start != 0)
-        sb.append (sep);
-      sb.append (source.substring (start, end));
+      if (sepFormat.indexOf (SEP_CHAR) == -1)
+      {
+        sb.append (source);
+        return;
+      }
+      else
+      {
+        StringBuilder reversed = new StringBuilder ();
+        // body must always end with non-sep, so here assume last format is non-sep
+        reversed.append (source.charAt (source.length () - 1));
+        for (int formatIndex = sepFormat.length () - 2, sourceIndex = source.length () - 2; formatIndex >= 0 ||
+          sourceIndex >= 0; formatIndex--)
+        {
+          if (formatIndex < 0)
+          {
+            for (int i = sourceIndex; i >= 0; i--)
+              reversed.append (source.charAt (i));
+            break;
+          }
+          else
+          {
+            if (sepFormat.charAt (formatIndex) == SEP_CHAR)
+              if (allowLeadingSep || sourceIndex >= 0)
+                reversed.append (SEP_CHAR);
+              else
+                break;
+            else
+              if (sourceIndex < 0)
+              {
+                break;
+              }
+              else
+              {
+                reversed.append (source.charAt (sourceIndex));
+                sourceIndex--;
+              }
+          }
+        }
+        sb.append (reversed.reverse ());
+      }
+    }
+    else
+    {
+      if (sepEvery < 1 || sepEvery >= source.length () || sepSize < 1)
+      {
+        sb.append (source);
+        return;
+      }
+      String sep = SEP_STRING.repeat (sepSize);
+      for (int start = 0, end = source.length () % sepEvery; end <= source.length (); start = end, end += sepEvery)
+      {
+        if (start != 0)
+          sb.append (sep);
+        sb.append (source.substring (start, end));
+      }
     }
   }
 
-  protected String pad (@NonNull String body, int qtty)
+  private static final char PAD_CHAR = '0';
+  private static final String PAD_STRING = String.valueOf (PAD_CHAR);
+
+  /// only for bases with padding enabled (so not decimal)
+  protected String padBody (@NonNull String body, int qtty)
   {
-    if (qtty <= body.length ())
+    if (!enablePadding || qtty <= body.length ())
       return body;
-    return "0".repeat (qtty - body.length ()) + body;
+    return PAD_STRING.repeat (qtty - body.length ()) + body;
+  }
+
+  protected String trimSeparators (@NonNull String body)
+  {
+    return body;
   }
 }

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/EIntegerBase.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/EIntegerBase.java
@@ -173,6 +173,8 @@ public enum EIntegerBase
       }
       else
       {
+        // since we use separators, we start from the last chars, so we reverse the separator format
+        // and build the reversed formatted representation.
         StringBuilder reversed = new StringBuilder ();
         // body must always end with non-sep, so here assume last format is non-sep
         reversed.append (source.charAt (source.length () - 1));

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/EIntegerBase.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/EIntegerBase.java
@@ -63,27 +63,21 @@ public enum EIntegerBase
   /// @return sb
   public StringBuilder represent (int i,
                                   StringBuilder sb,
-                                  boolean positiveSign,
-                                  boolean prefixUpper,
-                                  boolean bodyUpper,
-                                  int padding,
-                                  String sepFormat,
-                                  int sepEvery,
-                                  int sepSize)
+                                  IntegerRepresentation f)
   {
     boolean neg = i < 0;
     i = neg ? -i : i;
     if (neg)
       sb.append ('-');
     else
-      if (positiveSign)
+      if (f.positiveSign ())
         sb.append ('+');
-    sb.append (prefixUpper ? prefixUpperCased : prefixLowerCased);
-    addSep (padBody (caseBody (intFormat.apply (i), bodyUpper), padding),
-            sepFormat,
+    sb.append (f.prefixUpper () ? prefixUpperCased : prefixLowerCased);
+    addSep (padBody (caseBody (intFormat.apply (i), f.bodyUpper ()), f.padding ()),
+            f.separateFormat (),
             allowBodyLeadingSep,
-            sepEvery,
-            sepSize,
+            f.separateEvery (),
+            f.separatorSize (),
             sb);
     return sb;
   }
@@ -91,30 +85,23 @@ public enum EIntegerBase
   /// @return sb
   public StringBuilder represent (long l,
                                   StringBuilder sb,
-                                  boolean positiveSign,
-                                  boolean prefixUpper,
-                                  boolean bodyUpper,
-                                  int padding,
-                                  String sepFormat,
-                                  int sepEvery,
-                                  int sepSize,
-                                  boolean suffixUpper)
+                                  IntegerRepresentation f)
   {
     boolean neg = l < 0;
     l = neg ? -l : l;
     if (neg)
       sb.append ('-');
     else
-      if (positiveSign)
+      if (f.positiveSign ())
         sb.append ('+');
-    sb.append (prefixUpper ? prefixUpperCased : prefixLowerCased);
-    addSep (padBody (caseBody (longFormat.apply (l), bodyUpper), padding),
-            sepFormat,
+    sb.append (f.prefixUpper () ? prefixUpperCased : prefixLowerCased);
+    addSep (padBody (caseBody (longFormat.apply (l), f.bodyUpper ()), f.padding ()),
+            f.separateFormat (),
             allowBodyLeadingSep,
-            sepEvery,
-            sepSize,
+            f.separateEvery (),
+            f.separatorSize (),
             sb);
-    sb.append (suffixUpper ? 'L' : 'l');
+    sb.append (f.suffixUpper () ? 'L' : 'l');
     return sb;
   }
 

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/EIntegerBase.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/EIntegerBase.java
@@ -45,24 +45,43 @@ public enum EIntegerBase
   }
 
   /// @return sb
-  public StringBuilder represent (int i, StringBuilder sb, boolean prefixUpper, int padding, int sepEvery, int sepSize)
+  public StringBuilder represent (int i,
+                                  StringBuilder sb,
+                                  boolean positiveSign,
+                                  boolean prefixUpper,
+                                  int padding,
+                                  int sepEvery,
+                                  int sepSize)
   {
     boolean neg = i < 0;
     i = neg ? -i : i;
     if (neg)
       sb.append ('-');
+    else
+      if (positiveSign)
+        sb.append ('+');
     sb.append (prefixUpper ? prefixUpperCased : prefixLowerCased);
     addSep (pad (intFormat.apply (i), padding), sepEvery, sepSize, sb);
     return sb;
   }
 
   /// @return sb
-  public StringBuilder represent (long l, StringBuilder sb, boolean prefixUpper, int padding, int sepEvery, int sepSize, boolean suffixUpper)
+  public StringBuilder represent (long l,
+                                  StringBuilder sb,
+                                  boolean positiveSign,
+                                  boolean prefixUpper,
+                                  int padding,
+                                  int sepEvery,
+                                  int sepSize,
+                                  boolean suffixUpper)
   {
     boolean neg = l < 0;
     l = neg ? -l : l;
     if (neg)
       sb.append ('-');
+    else
+      if (positiveSign)
+        sb.append ('+');
     sb.append (prefixUpper ? prefixUpperCased : prefixLowerCased);
     addSep (pad (longFormat.apply (l), padding), sepEvery, sepSize, sb);
     sb.append (suffixUpper ? 'L' : 'l');

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerBase.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerBase.java
@@ -1,0 +1,93 @@
+package com.helger.jcodemodel.literals;
+
+import java.util.Locale;
+import java.util.function.IntFunction;
+import java.util.function.LongFunction;
+
+import org.jspecify.annotations.NonNull;
+
+/// base to represent an int/long in.
+/// 
+/// Those also contain the way to apply parameters when representing, in the corresponding represent methods 
+///
+/// @see https://docs.oracle.com/javase/specs/jls/se17/html/jls-3.html#jls-3.10.1
+public enum IntegerBase
+{
+  BINARY ("0b", Integer::toBinaryString, Long::toBinaryString),
+  DECIMAL ("", Integer::toString, Long::toString)
+  {
+    @Override
+    protected String pad (@NonNull String body, int qtty)
+    {
+      return body;
+    }
+  },
+  HEX ("0x", Integer::toHexString, Long::toHexString),
+  OCTAL ("0", Integer::toOctalString, Long::toOctalString);
+
+  @NonNull
+  final IntFunction <String> intFormat;
+
+  @NonNull
+  final LongFunction <String> longFormat;
+
+  @NonNull
+  final String prefixLowerCased;
+  @NonNull
+  final String prefixUpperCased;
+
+  IntegerBase (String prefix, IntFunction <String> intFormat, LongFunction <String> longFormat)
+  {
+    this.prefixLowerCased = prefix.toLowerCase (Locale.ROOT);
+    this.prefixUpperCased = prefix.toUpperCase (Locale.ROOT);
+    this.intFormat = intFormat;
+    this.longFormat = longFormat;
+  }
+
+  public StringBuilder represent (int i, StringBuilder sb, boolean prefixUpper, int padding, int sepEvery, int sepSize)
+  {
+    boolean neg = i < 0;
+    i = neg ? -i : i;
+    if (neg)
+      sb.append ('-');
+    sb.append (prefixUpper ? prefixUpperCased : prefixLowerCased);
+    addSep (pad (intFormat.apply (i), padding), sepEvery, sepSize, sb);
+    return sb;
+  }
+
+  public StringBuilder represent (long l, StringBuilder sb, boolean prefixUpper, int padding, int sepEvery, int sepSize, boolean suffixUpper)
+  {
+    boolean neg = l < 0;
+    l = neg ? -l : l;
+    if (neg)
+      sb.append ('-');
+    sb.append (prefixUpper ? prefixUpperCased : prefixLowerCased);
+    addSep (pad (longFormat.apply (l), padding), sepEvery, sepSize, sb);
+    sb.append (suffixUpper ? 'L' : 'l');
+    return sb;
+  }
+
+  /// @param source unsigned non-prefixed representation , eg a5 for -0xa5 .
+  static void addSep (@NonNull String source, int sepEvery, int sepSize, StringBuilder sb)
+  {
+    if (sepEvery < 1 || sepEvery >= source.length () || sepSize < 1)
+    {
+      sb.append (source);
+      return;
+    }
+    String sep = "_".repeat (sepSize);
+    for (int start = 0, end = source.length () % sepEvery; end <= source.length (); start = end, end += sepEvery)
+    {
+      if (start != 0)
+        sb.append (sep);
+      sb.append (source.substring (start, end));
+    }
+  }
+
+  protected String pad (@NonNull String body, int qtty)
+  {
+    if (qtty <= body.length ())
+      return body;
+    return "0".repeat (qtty - body.length ()) + body;
+  }
+}

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
@@ -166,37 +166,37 @@ public record IntegerRepresentation (
 
   public IntegerRepresentation positiveSign (boolean positiveSign)
   {
-    return with (ir -> { ir.positiveSign = positiveSign; });
+    return positiveSign == this.positiveSign ? this : with (ir -> { ir.positiveSign = positiveSign; });
   }
 
   public IntegerRepresentation prefixUpper (boolean prefixUpper)
   {
-    return with (ir -> { ir.prefixUpper = prefixUpper; });
+    return prefixUpper == this.prefixUpper ? this : with (ir -> { ir.prefixUpper = prefixUpper; });
   }
 
   public IntegerRepresentation base (@NonNull EIntegerBase base)
   {
-    return with (ir -> { ir.base = base; });
+    return base == this.base ? this : with (ir -> { ir.base = base; });
   }
 
   public IntegerRepresentation padding (int padding)
   {
-    return with (ir -> { ir.padding = padding; });
+    return padding == this.padding ? this : with (ir -> { ir.padding = padding; });
   }
 
   public IntegerRepresentation separateEvery (int separateEvery)
   {
-    return with (ir -> { ir.separateEvery = separateEvery; });
+    return separateEvery == this.separateEvery ? this : with (ir -> { ir.separateEvery = separateEvery; });
   }
 
   public IntegerRepresentation separatorSize (int separatorSize)
   {
-    return with (ir -> { ir.separatorSize = separatorSize; });
+    return separatorSize == this.separatorSize ? this : with (ir -> { ir.separatorSize = separatorSize; });
   }
 
-  public IntegerRepresentation sufixUpper (boolean sufixUpper)
+  public IntegerRepresentation sufixUpper (boolean suffixUpper)
   {
-    return with (ir -> { ir.suffixUpper = sufixUpper; });
+    return suffixUpper == this.suffixUpper ? this : with (ir -> { ir.suffixUpper = suffixUpper; });
   }
 
   //

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
@@ -23,6 +23,8 @@ public record IntegerRepresentation (
                                      /// the base in which we want to represent the number, eg
                                      /// octal, binary
                                      @NonNull EIntegerBase base,
+                                     // if using hex, should we uppercase the body ?
+                                     boolean bodyUpper,
                                      /// if possible (not dec base), append 0 to make the
                                      /// representation's body at least
                                      int padding,
@@ -68,6 +70,7 @@ public record IntegerRepresentation (
   public static final IntegerRepresentation DEFAULT = new IntegerRepresentation (false,
                                                                                  false,
                                                                                  EIntegerBase.DECIMAL,
+                                                                                 true,
                                                                                  0,
                                                                                  null,
                                                                                  0,
@@ -78,6 +81,7 @@ public record IntegerRepresentation (
   public static final IntegerRepresentation BIN = DEFAULT.with (null,
                                                                 null,
                                                                 EIntegerBase.BINARY,
+                                                                null,
                                                                 null,
                                                                 null,
                                                                 8,
@@ -96,6 +100,7 @@ public record IntegerRepresentation (
                                                                 EIntegerBase.HEXADECIMAL,
                                                                 null,
                                                                 null,
+                                                                null,
                                                                 2,
                                                                 null,
                                                                 null);
@@ -104,6 +109,7 @@ public record IntegerRepresentation (
   public static final IntegerRepresentation OCT = DEFAULT.with (null,
                                                                 null,
                                                                 EIntegerBase.OCTAL,
+                                                                null,
                                                                 null,
                                                                 null,
                                                                 4,
@@ -119,6 +125,7 @@ public record IntegerRepresentation (
     return new IntegerRepresentation (positiveSign,
                                       prefixUpper,
                                       base,
+                                      bodyUpper,
                                       padding,
                                       separateFormat,
                                       separateEvery,
@@ -131,6 +138,7 @@ public record IntegerRepresentation (
     return new IntegerRepresentation (positiveSign,
                                       prefixUpper,
                                       base,
+                                      bodyUpper,
                                       padding,
                                       separateFormat,
                                       separateEvery,
@@ -143,6 +151,7 @@ public record IntegerRepresentation (
     return new IntegerRepresentation (positiveSign,
                                       prefixUpper,
                                       base,
+                                      bodyUpper,
                                       padding,
                                       separateFormat,
                                       separateEvery,
@@ -155,6 +164,7 @@ public record IntegerRepresentation (
     return new IntegerRepresentation (positiveSign,
                                       prefixUpper,
                                       base,
+                                      bodyUpper,
                                       padding,
                                       separateFormat,
                                       separateEvery,
@@ -167,6 +177,7 @@ public record IntegerRepresentation (
     return new IntegerRepresentation (positiveSign,
                                       prefixUpper,
                                       base,
+                                      bodyUpper,
                                       padding,
                                       separateFormat,
                                       separateEvery,
@@ -179,6 +190,7 @@ public record IntegerRepresentation (
     return new IntegerRepresentation (positiveSign,
                                       prefixUpper,
                                       base,
+                                      bodyUpper,
                                       padding,
                                       separateFormat,
                                       separateEvery,
@@ -191,6 +203,7 @@ public record IntegerRepresentation (
     return new IntegerRepresentation (positiveSign,
                                       prefixUpper,
                                       base,
+                                      bodyUpper,
                                       padding,
                                       separateFormat,
                                       separateEvery,
@@ -204,6 +217,7 @@ public record IntegerRepresentation (
   public IntegerRepresentation with (Boolean newPositiveSign,
                                      Boolean newPrefixUpper,
                                      EIntegerBase newBase,
+                                     Boolean newBodyUpper,
                                      Integer newPadding,
                                      Optional <String> newSeparateFormat,
                                      Integer newSepEvery,
@@ -213,6 +227,7 @@ public record IntegerRepresentation (
     if ((newPositiveSign == null || newPositiveSign == positiveSign) &&
       (newPrefixUpper == null || newPrefixUpper == prefixUpper) &&
       (newBase == null || newBase == base) &&
+      (newBodyUpper == null || newBodyUpper == bodyUpper) &&
       (newPadding == null || newPadding == padding) &&
       (newSeparateFormat == null || newSeparateFormat.orElse (null) == separateFormat) &&
       (newSepEvery == null || newSepEvery == separateEvery) &&
@@ -224,6 +239,7 @@ public record IntegerRepresentation (
     return new IntegerRepresentation (newPositiveSign == null ? positiveSign : newPositiveSign,
                                       newPrefixUpper == null ? prefixUpper : newPrefixUpper,
                                       newBase == null ? base : newBase,
+                                      newBodyUpper == null ? bodyUpper : newBodyUpper,
                                       newPadding == null ? padding : newPadding,
                                       newSeparateFormat == null ? separateFormat : newSeparateFormat.orElse (null),
                                       newSepEvery == null ? separateEvery : newSepEvery,
@@ -241,6 +257,7 @@ public record IntegerRepresentation (
                            new StringBuilder (),
                            positiveSign,
                            prefixUpper,
+                           bodyUpper,
                            padding,
                            separateFormat,
                            separateEvery,
@@ -254,6 +271,7 @@ public record IntegerRepresentation (
                            new StringBuilder (),
                            positiveSign,
                            prefixUpper,
+                           bodyUpper,
                            padding,
                            separateFormat,
                            separateEvery,

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 
 import org.jspecify.annotations.NonNull;
 
-/// record containing the params to represent an int/long 
+/// record containing the params to represent an int/long. This is mostly a carrier, the actual behavior is in the base.
 /// 
 /// a representation is made of a prefix, a body, and a suffix 
 ///  - The prefix is absent for decimal, but discriminant for other bases.
@@ -18,7 +18,7 @@ public record IntegerRepresentation (
                                      boolean prefixUpper,
                                      /// the base in which we want to represent the number, eg octal, binary
                                      @NonNull
-                                     IntegerBase base,
+                                     EIntegerBase base,
                                      /// if possible (not dec base), append 0 to make the representation's body at least   
                                      int padding,
                                      /// how many characters to skip in the body before adding a
@@ -45,7 +45,7 @@ public record IntegerRepresentation (
   /// - if adding separators, use size 1
   /// - for long type, uppercase the terminal "L"
   public static final IntegerRepresentation DEFAULT = new IntegerRepresentation (false,
-                                                                                 IntegerBase.DECIMAL,
+                                                                                 EIntegerBase.DECIMAL,
                                                                                  0,
                                                                                  0,
                                                                                  1,
@@ -60,7 +60,7 @@ public record IntegerRepresentation (
     return new IntegerRepresentation (prefixUpper, base, padding, separateEvery, separatorSize, sufixUpper);
   }
 
-  public IntegerRepresentation base (IntegerBase base)
+  public IntegerRepresentation base (EIntegerBase base)
   {
     return new IntegerRepresentation (prefixUpper, base, padding, separateEvery, separatorSize, sufixUpper);
   }
@@ -85,10 +85,10 @@ public record IntegerRepresentation (
     return new IntegerRepresentation (prefixUpper, base, padding, separateEvery, separatorSize, sufixUpper);
   }
 
-  /// @return new record with fields overwritten by non-null params.
   /// This is present to avoid long chains of configuration when updating from a base model
+  /// @return new record with fields overwritten by non-null params.
   public IntegerRepresentation with (Boolean newPrefixUpper,
-                                     IntegerBase newBase,
+                                     EIntegerBase newBase,
                                      Integer newPadding,
                                      Integer newSepEvery,
                                      Integer newSepSize,

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
@@ -1,7 +1,7 @@
 package com.helger.jcodemodel.literals;
 
 import java.util.Objects;
-import java.util.Optional;
+import java.util.function.Consumer;
 
 import org.jspecify.annotations.NonNull;
 
@@ -42,7 +42,7 @@ public record IntegerRepresentation (
                                      int separatorSize,
                                      /// if representing long, should we uppercase the terminal "l"
                                      /// ?
-                                     boolean sufixUpper)
+                                     boolean suffixUpper)
 {
 
   // validation
@@ -50,6 +50,64 @@ public record IntegerRepresentation (
   public IntegerRepresentation
   {
     Objects.requireNonNull (base);
+  }
+
+  // copier
+
+  /// Intermediate mutable class for mutate a record. Waiting for java withers …
+  public static class Copier
+  {
+    public boolean positiveSign;
+    public boolean prefixUpper;
+    public EIntegerBase base;
+    public boolean bodyUpper;
+    public int padding;
+    public String separateFormat;
+    public int separateEvery;
+    public int separatorSize;
+    public boolean suffixUpper;
+
+    Copier(IntegerRepresentation ir){
+      positiveSign=ir.positiveSign;
+      prefixUpper = ir.prefixUpper;
+      base=ir.base;
+      bodyUpper=ir.bodyUpper;
+      padding=ir.padding;
+      separateFormat=ir.separateFormat;
+      separateEvery=ir.separateEvery;
+      separatorSize=ir.separatorSize;
+      suffixUpper = ir.suffixUpper;
+    }
+
+    IntegerRepresentation toRecord ()
+    {
+      return new IntegerRepresentation (positiveSign,
+                                        prefixUpper,
+                                        base,
+                                        bodyUpper,
+                                        padding,
+                                        separateFormat,
+                                        separateEvery,
+                                        separatorSize,
+                                        suffixUpper);
+    }
+
+    public Copier apply (Consumer <Copier> c)
+    {
+      c.accept (this);
+      return this;
+    }
+
+  }
+
+  public Copier copier ()
+  {
+    return new Copier (this);
+  }
+
+  public IntegerRepresentation with (Consumer <Copier> change)
+  {
+    return copier ().apply (change).toRecord ();
   }
 
   // default values
@@ -78,15 +136,10 @@ public record IntegerRepresentation (
                                                                                  true);
 
   /// print binary with 8-chars separations, eg "1_00000000" or "1_00000000_00000000L"
-  public static final IntegerRepresentation BIN = DEFAULT.with (null,
-                                                                null,
-                                                                EIntegerBase.BINARY,
-                                                                null,
-                                                                null,
-                                                                null,
-                                                                8,
-                                                                null,
-                                                                null);
+  public static final IntegerRepresentation BIN = DEFAULT.with (ir -> {
+    ir.base = EIntegerBase.BINARY;
+    ir.separateEvery = 8;
+  });
 
   /// bits with padding to 8 chars
   public static final IntegerRepresentation BIN8 = BIN.padding (8);
@@ -95,26 +148,16 @@ public record IntegerRepresentation (
   public static final IntegerRepresentation DEC = DEFAULT.separateEvery (3);
 
   // print hexa with 2-chars separations, eg "0xAA_BB"
-  public static final IntegerRepresentation HEX = DEFAULT.with (null,
-                                                                null,
-                                                                EIntegerBase.HEXADECIMAL,
-                                                                null,
-                                                                null,
-                                                                null,
-                                                                2,
-                                                                null,
-                                                                null);
+  public static final IntegerRepresentation HEX = DEFAULT.with (ir -> {
+    ir.base = EIntegerBase.HEXADECIMAL;
+    ir.separateEvery = 2;
+  });
 
   // print octal with 4-chars separations, eg "01_0000"
-  public static final IntegerRepresentation OCT = DEFAULT.with (null,
-                                                                null,
-                                                                EIntegerBase.OCTAL,
-                                                                null,
-                                                                null,
-                                                                null,
-                                                                4,
-                                                                null,
-                                                                null);
+  public static final IntegerRepresentation OCT = DEFAULT.with (ir -> {
+    ir.base = EIntegerBase.OCTAL;
+    ir.separateEvery = 4;
+  });
 
   //
   // mutators
@@ -122,129 +165,37 @@ public record IntegerRepresentation (
 
   public IntegerRepresentation positiveSign (boolean positiveSign)
   {
-    return new IntegerRepresentation (positiveSign,
-                                      prefixUpper,
-                                      base,
-                                      bodyUpper,
-                                      padding,
-                                      separateFormat,
-                                      separateEvery,
-                                      separatorSize,
-                                      sufixUpper);
+    return with (ir -> { ir.positiveSign = positiveSign; });
   }
 
   public IntegerRepresentation prefixUpper (boolean prefixUpper)
   {
-    return new IntegerRepresentation (positiveSign,
-                                      prefixUpper,
-                                      base,
-                                      bodyUpper,
-                                      padding,
-                                      separateFormat,
-                                      separateEvery,
-                                      separatorSize,
-                                      sufixUpper);
+    return with (ir -> { ir.prefixUpper = prefixUpper; });
   }
 
   public IntegerRepresentation base (EIntegerBase base)
   {
-    return new IntegerRepresentation (positiveSign,
-                                      prefixUpper,
-                                      base,
-                                      bodyUpper,
-                                      padding,
-                                      separateFormat,
-                                      separateEvery,
-                                      separatorSize,
-                                      sufixUpper);
+    return with (ir -> { ir.base = base; });
   }
 
   public IntegerRepresentation padding (int padding)
   {
-    return new IntegerRepresentation (positiveSign,
-                                      prefixUpper,
-                                      base,
-                                      bodyUpper,
-                                      padding,
-                                      separateFormat,
-                                      separateEvery,
-                                      separatorSize,
-                                      sufixUpper);
+    return with (ir -> { ir.padding = padding; });
   }
 
   public IntegerRepresentation separateEvery (int separateEvery)
   {
-    return new IntegerRepresentation (positiveSign,
-                                      prefixUpper,
-                                      base,
-                                      bodyUpper,
-                                      padding,
-                                      separateFormat,
-                                      separateEvery,
-                                      separatorSize,
-                                      sufixUpper);
+    return with (ir -> { ir.separateEvery = separateEvery; });
   }
 
   public IntegerRepresentation separatorSize (int separatorSize)
   {
-    return new IntegerRepresentation (positiveSign,
-                                      prefixUpper,
-                                      base,
-                                      bodyUpper,
-                                      padding,
-                                      separateFormat,
-                                      separateEvery,
-                                      separatorSize,
-                                      sufixUpper);
+    return with (ir -> { ir.separatorSize = separatorSize; });
   }
 
   public IntegerRepresentation sufixUpper (boolean sufixUpper)
   {
-    return new IntegerRepresentation (positiveSign,
-                                      prefixUpper,
-                                      base,
-                                      bodyUpper,
-                                      padding,
-                                      separateFormat,
-                                      separateEvery,
-                                      separatorSize,
-                                      sufixUpper);
-  }
-
-  /// This is present to avoid long chains of configuration when updating from a base model
-  ///
-  /// @return new record with fields overwritten by non-null params.
-  public IntegerRepresentation with (Boolean newPositiveSign,
-                                     Boolean newPrefixUpper,
-                                     EIntegerBase newBase,
-                                     Boolean newBodyUpper,
-                                     Integer newPadding,
-                                     Optional <String> newSeparateFormat,
-                                     Integer newSepEvery,
-                                     Integer newSepSize,
-                                     Boolean newSuffixUpper)
-  {
-    if ((newPositiveSign == null || newPositiveSign == positiveSign) &&
-      (newPrefixUpper == null || newPrefixUpper == prefixUpper) &&
-      (newBase == null || newBase == base) &&
-      (newBodyUpper == null || newBodyUpper == bodyUpper) &&
-      (newPadding == null || newPadding == padding) &&
-      (newSeparateFormat == null || newSeparateFormat.orElse (null) == separateFormat) &&
-      (newSepEvery == null || newSepEvery == separateEvery) &&
-      (newSepSize == null || newSepSize == separatorSize) &&
-      (newSuffixUpper == null || newSuffixUpper == sufixUpper))
-    {
-      return this;
-    }
-    return new IntegerRepresentation (newPositiveSign == null ? positiveSign : newPositiveSign,
-                                      newPrefixUpper == null ? prefixUpper : newPrefixUpper,
-                                      newBase == null ? base : newBase,
-                                      newBodyUpper == null ? bodyUpper : newBodyUpper,
-                                      newPadding == null ? padding : newPadding,
-                                      newSeparateFormat == null ? separateFormat : newSeparateFormat.orElse (null),
-                                      newSepEvery == null ? separateEvery : newSepEvery,
-                                      newSepSize == null ? separatorSize : newSepSize,
-                                      newSuffixUpper == null ? sufixUpper : newSuffixUpper);
+    return with (ir -> { ir.suffixUpper = sufixUpper; });
   }
 
   //
@@ -253,30 +204,12 @@ public record IntegerRepresentation (
 
   public String format (int i)
   {
-    return base.represent (i,
-                           new StringBuilder (),
-                           positiveSign,
-                           prefixUpper,
-                           bodyUpper,
-                           padding,
-                           separateFormat,
-                           separateEvery,
-                           separatorSize)
-               .toString ();
+    return base.represent (i, new StringBuilder (), this).toString ();
   }
 
   public String format (long l)
   {
-    return base.represent (l,
-                           new StringBuilder (),
-                           positiveSign,
-                           prefixUpper,
-                           bodyUpper,
-                           padding,
-                           separateFormat,
-                           separateEvery,
-                           separatorSize,
-                           sufixUpper).toString ();
+    return base.represent (l, new StringBuilder (), this).toString ();
   }
 
 }

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
@@ -4,9 +4,10 @@ import java.util.Objects;
 
 import org.jspecify.annotations.NonNull;
 
-/// record containing the params to represent an int/long. This is mostly a carrier, the actual behavior is in the base.
+/// record containing the params to represent an int/long. This is mostly a data carrier, the actual behavior is in the base.
 /// 
-/// a representation is made of a prefix, a body, and a suffix 
+/// A representation is made using a base, of a prefix, a body, and a suffix, with :
+///  
 ///  - The prefix is absent for decimal, but discriminant for other bases.
 ///  - The prefix can be set upper or lower (as prefix "0x" is same as "0X" )
 ///  - The body is never empty, the actual representation depends on the base
@@ -32,24 +33,45 @@ public record IntegerRepresentation (
 {
 
   // validation
+
   public IntegerRepresentation
   {
     Objects.requireNonNull (base);
   }
 
-  /// Default options are
+  // default values
+
+  /// Default options are :
+  ///
+  /// - use decimal base.
   /// - lowercase the prefix, so "0x" instead of "0X"
-  /// - use decimal representation
   /// - no padding of the body
   /// - no separator
   /// - if adding separators, use size 1
   /// - for long type, uppercase the terminal "L"
+  ///
+  /// from spec :
+  /// > The suffix L is preferred, because the letter l (ell) is often hard to distinguish from the
+  /// > digit 1 (one).
+  ///
   public static final IntegerRepresentation DEFAULT = new IntegerRepresentation (false,
                                                                                  EIntegerBase.DECIMAL,
                                                                                  0,
                                                                                  0,
                                                                                  1,
                                                                                  true);
+
+  /// print decimals with 3-chars separations, eg "1_000" or "1_234_567L"
+  public static final IntegerRepresentation DEC = DEFAULT.separateEvery (3);
+
+  /// print binary with 8-chars separations, eg "1_00000000" or "1_00000000_00000000L"
+  public static final IntegerRepresentation BIN = DEFAULT.with (null, EIntegerBase.BINARY, null, 8, null, null);
+
+  /// bits with padding to 8 chars
+  public static final IntegerRepresentation BIN8 = BIN.padding (8);
+
+  // print hexa with 2-chars separations, eg "0xAA_BB"
+  public static final IntegerRepresentation HEX = DEFAULT.with (null, EIntegerBase.HEX, null, 2, null, null);
 
   //
   // mutators

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
@@ -1,6 +1,7 @@
 package com.helger.jcodemodel.literals;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import org.jspecify.annotations.NonNull;
 
@@ -25,6 +26,13 @@ public record IntegerRepresentation (
                                      /// if possible (not dec base), append 0 to make the
                                      /// representation's body at least
                                      int padding,
+                                     /// when non null, specifies where to put underscores in the
+                                     /// body.
+                                     /// For example, " _ __ " requires to add 2 underscores before
+                                     /// the last char and 1 before the one before. Note that
+                                     /// leading underscores may be discarded, depending on the
+                                     /// base.
+                                     String separateFormat,
                                      /// how many characters to skip in the body before adding a
                                      /// separator String.
                                      int separateEvery,
@@ -61,12 +69,20 @@ public record IntegerRepresentation (
                                                                                  false,
                                                                                  EIntegerBase.DECIMAL,
                                                                                  0,
+                                                                                 null,
                                                                                  0,
                                                                                  1,
                                                                                  true);
 
   /// print binary with 8-chars separations, eg "1_00000000" or "1_00000000_00000000L"
-  public static final IntegerRepresentation BIN = DEFAULT.with (null, null, EIntegerBase.BINARY, null, 8, null, null);
+  public static final IntegerRepresentation BIN = DEFAULT.with (null,
+                                                                null,
+                                                                EIntegerBase.BINARY,
+                                                                null,
+                                                                null,
+                                                                8,
+                                                                null,
+                                                                null);
 
   /// bits with padding to 8 chars
   public static final IntegerRepresentation BIN8 = BIN.padding (8);
@@ -79,12 +95,20 @@ public record IntegerRepresentation (
                                                                 null,
                                                                 EIntegerBase.HEXADECIMAL,
                                                                 null,
+                                                                null,
                                                                 2,
                                                                 null,
                                                                 null);
 
   // print octal with 4-chars separations, eg "01_0000"
-  public static final IntegerRepresentation OCT = DEFAULT.with (null, null, EIntegerBase.OCTAL, null, 4, null, null);
+  public static final IntegerRepresentation OCT = DEFAULT.with (null,
+                                                                null,
+                                                                EIntegerBase.OCTAL,
+                                                                null,
+                                                                null,
+                                                                4,
+                                                                null,
+                                                                null);
 
   //
   // mutators
@@ -96,6 +120,7 @@ public record IntegerRepresentation (
                                       prefixUpper,
                                       base,
                                       padding,
+                                      separateFormat,
                                       separateEvery,
                                       separatorSize,
                                       sufixUpper);
@@ -107,6 +132,7 @@ public record IntegerRepresentation (
                                       prefixUpper,
                                       base,
                                       padding,
+                                      separateFormat,
                                       separateEvery,
                                       separatorSize,
                                       sufixUpper);
@@ -118,6 +144,7 @@ public record IntegerRepresentation (
                                       prefixUpper,
                                       base,
                                       padding,
+                                      separateFormat,
                                       separateEvery,
                                       separatorSize,
                                       sufixUpper);
@@ -129,6 +156,7 @@ public record IntegerRepresentation (
                                       prefixUpper,
                                       base,
                                       padding,
+                                      separateFormat,
                                       separateEvery,
                                       separatorSize,
                                       sufixUpper);
@@ -140,6 +168,7 @@ public record IntegerRepresentation (
                                       prefixUpper,
                                       base,
                                       padding,
+                                      separateFormat,
                                       separateEvery,
                                       separatorSize,
                                       sufixUpper);
@@ -151,6 +180,7 @@ public record IntegerRepresentation (
                                       prefixUpper,
                                       base,
                                       padding,
+                                      separateFormat,
                                       separateEvery,
                                       separatorSize,
                                       sufixUpper);
@@ -162,17 +192,20 @@ public record IntegerRepresentation (
                                       prefixUpper,
                                       base,
                                       padding,
+                                      separateFormat,
                                       separateEvery,
                                       separatorSize,
                                       sufixUpper);
   }
 
   /// This is present to avoid long chains of configuration when updating from a base model
+  ///
   /// @return new record with fields overwritten by non-null params.
   public IntegerRepresentation with (Boolean newPositiveSign,
                                      Boolean newPrefixUpper,
                                      EIntegerBase newBase,
                                      Integer newPadding,
+                                     Optional <String> newSeparateFormat,
                                      Integer newSepEvery,
                                      Integer newSepSize,
                                      Boolean newSuffixUpper)
@@ -181,6 +214,7 @@ public record IntegerRepresentation (
       (newPrefixUpper == null || newPrefixUpper == prefixUpper) &&
       (newBase == null || newBase == base) &&
       (newPadding == null || newPadding == padding) &&
+      (newSeparateFormat == null || newSeparateFormat.orElse (null) == separateFormat) &&
       (newSepEvery == null || newSepEvery == separateEvery) &&
       (newSepSize == null || newSepSize == separatorSize) &&
       (newSuffixUpper == null || newSuffixUpper == sufixUpper))
@@ -191,6 +225,7 @@ public record IntegerRepresentation (
                                       newPrefixUpper == null ? prefixUpper : newPrefixUpper,
                                       newBase == null ? base : newBase,
                                       newPadding == null ? padding : newPadding,
+                                      newSeparateFormat == null ? separateFormat : newSeparateFormat.orElse (null),
                                       newSepEvery == null ? separateEvery : newSepEvery,
                                       newSepSize == null ? separatorSize : newSepSize,
                                       newSuffixUpper == null ? sufixUpper : newSuffixUpper);
@@ -202,7 +237,14 @@ public record IntegerRepresentation (
 
   public String format (int i)
   {
-    return base.represent (i, new StringBuilder (), positiveSign, prefixUpper, padding, separateEvery, separatorSize)
+    return base.represent (i,
+                           new StringBuilder (),
+                           positiveSign,
+                           prefixUpper,
+                           padding,
+                           separateFormat,
+                           separateEvery,
+                           separatorSize)
                .toString ();
   }
 
@@ -213,6 +255,7 @@ public record IntegerRepresentation (
                            positiveSign,
                            prefixUpper,
                            padding,
+                           separateFormat,
                            separateEvery,
                            separatorSize,
                            sufixUpper).toString ();

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
@@ -1,0 +1,91 @@
+package com.helger.jcodemodel.literals;
+
+/// record containing the params to represent an int/long 
+/// 
+/// a representation is made of a prefix, a body, and a suffix 
+///  - The prefix is absent for decimal, but discriminant for other bases.
+///  - The prefix can be set upper or lower (as prefix "0x" is same as "0X" )
+///  - The body is never empty, the actual representation depends on the base
+///  - once build from the base, the body *may* be padded, if requested, depending on the base (dec base does not allow padding)
+///  - separator are then applied to the (padded) body, using "_"
+///  - suffix is only present for long type. They can be upper or lower cased.
+public record IntegerRepresentation (
+                                     /// if the base needs a prefix, should we uppercase it ?
+                                     boolean prefixUpper,
+                                     /// the base in which we want to represent the number, eg octal, binary
+                                     IntegerBase base,
+                                     /// if possible (not dec base), append 0 to make the representation's body at least   
+                                     int padding,
+                                     /// how many characters to skip in the body before adding a
+                                     /// separator String.
+                                     int separateEvery,
+                                     /// number of "_" characters a separator string is made of.
+                                     int separatorSize,
+                                     /// if representing long, should we uppercase the terminal "l"
+                                     boolean sufixUpper)
+{
+
+  /// Default options are
+  /// - lowercase the prefix, so "0x" instead of "0X"
+  /// - use decimal representation
+  /// - no padding of the body
+  /// - no separator
+  /// - if adding separators, use size 1
+  /// - for long type, uppercase the terminal "L"
+  public static final IntegerRepresentation DEFAULT = new IntegerRepresentation (false,
+                                                                                 IntegerBase.DECIMAL,
+                                                                                 0,
+                                                                                 0,
+                                                                                 1,
+                                                                                 true);
+
+  //
+  // mutators
+  //
+
+  public IntegerRepresentation prefixUppder (boolean prefixUpper)
+  {
+    return new IntegerRepresentation (prefixUpper, base, padding, separateEvery, separatorSize, sufixUpper);
+  }
+
+  public IntegerRepresentation base (IntegerBase base)
+  {
+    return new IntegerRepresentation (prefixUpper, base, padding, separateEvery, separatorSize, sufixUpper);
+  }
+
+  public IntegerRepresentation padding (int padding)
+  {
+    return new IntegerRepresentation (prefixUpper, base, padding, separateEvery, separatorSize, sufixUpper);
+  }
+
+  public IntegerRepresentation separateEvery (int separateEvery)
+  {
+    return new IntegerRepresentation (prefixUpper, base, padding, separateEvery, separatorSize, sufixUpper);
+  }
+
+  public IntegerRepresentation separatorSize (int separatorSize)
+  {
+    return new IntegerRepresentation (prefixUpper, base, padding, separateEvery, separatorSize, sufixUpper);
+  }
+
+  public IntegerRepresentation sufixUpper (boolean sufixUpper)
+  {
+    return new IntegerRepresentation (prefixUpper, base, padding, separateEvery, separatorSize, sufixUpper);
+  }
+
+  //
+  // actual formatting is delegated to the base
+  //
+
+  public String format (int i)
+  {
+    return base.represent (i, new StringBuilder (), prefixUpper, padding, separateEvery, separatorSize).toString ();
+  }
+
+  public String format (long l)
+  {
+    return base.represent (l, new StringBuilder (), prefixUpper, padding, separateEvery, separatorSize, sufixUpper)
+               .toString ();
+  }
+
+}

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
@@ -15,6 +15,8 @@ import org.jspecify.annotations.NonNull;
 ///  - separator are then applied to the (padded) body, using "_"
 ///  - suffix is only present for long type. They can be upper or lower cased.
 public record IntegerRepresentation (
+                                     /// should we print '+' if the number is positive ?
+                                     boolean positiveSign,
                                      /// if the base needs a prefix, should we uppercase it ?
                                      boolean prefixUpper,
                                      /// the base in which we want to represent the number, eg octal, binary
@@ -55,6 +57,7 @@ public record IntegerRepresentation (
   /// > digit 1 (one).
   ///
   public static final IntegerRepresentation DEFAULT = new IntegerRepresentation (false,
+                                                                                 false,
                                                                                  EIntegerBase.DECIMAL,
                                                                                  0,
                                                                                  0,
@@ -65,58 +68,107 @@ public record IntegerRepresentation (
   public static final IntegerRepresentation DEC = DEFAULT.separateEvery (3);
 
   /// print binary with 8-chars separations, eg "1_00000000" or "1_00000000_00000000L"
-  public static final IntegerRepresentation BIN = DEFAULT.with (null, EIntegerBase.BINARY, null, 8, null, null);
+  public static final IntegerRepresentation BIN = DEFAULT.with (null, null, EIntegerBase.BINARY, null, 8, null, null);
 
   /// bits with padding to 8 chars
   public static final IntegerRepresentation BIN8 = BIN.padding (8);
 
   // print hexa with 2-chars separations, eg "0xAA_BB"
-  public static final IntegerRepresentation HEX = DEFAULT.with (null, EIntegerBase.HEX, null, 2, null, null);
+  public static final IntegerRepresentation HEX = DEFAULT.with (null, null, EIntegerBase.HEX, null, 2, null, null);
 
   //
   // mutators
   //
 
-  public IntegerRepresentation prefixUppder (boolean prefixUpper)
+  public IntegerRepresentation positiveSign (boolean positiveSign)
   {
-    return new IntegerRepresentation (prefixUpper, base, padding, separateEvery, separatorSize, sufixUpper);
+    return new IntegerRepresentation (positiveSign,
+                                      prefixUpper,
+                                      base,
+                                      padding,
+                                      separateEvery,
+                                      separatorSize,
+                                      sufixUpper);
+  }
+
+  public IntegerRepresentation prefixUpper (boolean prefixUpper)
+  {
+    return new IntegerRepresentation (positiveSign,
+                                      prefixUpper,
+                                      base,
+                                      padding,
+                                      separateEvery,
+                                      separatorSize,
+                                      sufixUpper);
   }
 
   public IntegerRepresentation base (EIntegerBase base)
   {
-    return new IntegerRepresentation (prefixUpper, base, padding, separateEvery, separatorSize, sufixUpper);
+    return new IntegerRepresentation (positiveSign,
+                                      prefixUpper,
+                                      base,
+                                      padding,
+                                      separateEvery,
+                                      separatorSize,
+                                      sufixUpper);
   }
 
   public IntegerRepresentation padding (int padding)
   {
-    return new IntegerRepresentation (prefixUpper, base, padding, separateEvery, separatorSize, sufixUpper);
+    return new IntegerRepresentation (positiveSign,
+                                      prefixUpper,
+                                      base,
+                                      padding,
+                                      separateEvery,
+                                      separatorSize,
+                                      sufixUpper);
   }
 
   public IntegerRepresentation separateEvery (int separateEvery)
   {
-    return new IntegerRepresentation (prefixUpper, base, padding, separateEvery, separatorSize, sufixUpper);
+    return new IntegerRepresentation (positiveSign,
+                                      prefixUpper,
+                                      base,
+                                      padding,
+                                      separateEvery,
+                                      separatorSize,
+                                      sufixUpper);
   }
 
   public IntegerRepresentation separatorSize (int separatorSize)
   {
-    return new IntegerRepresentation (prefixUpper, base, padding, separateEvery, separatorSize, sufixUpper);
+    return new IntegerRepresentation (positiveSign,
+                                      prefixUpper,
+                                      base,
+                                      padding,
+                                      separateEvery,
+                                      separatorSize,
+                                      sufixUpper);
   }
 
   public IntegerRepresentation sufixUpper (boolean sufixUpper)
   {
-    return new IntegerRepresentation (prefixUpper, base, padding, separateEvery, separatorSize, sufixUpper);
+    return new IntegerRepresentation (positiveSign,
+                                      prefixUpper,
+                                      base,
+                                      padding,
+                                      separateEvery,
+                                      separatorSize,
+                                      sufixUpper);
   }
 
   /// This is present to avoid long chains of configuration when updating from a base model
   /// @return new record with fields overwritten by non-null params.
-  public IntegerRepresentation with (Boolean newPrefixUpper,
+  public IntegerRepresentation with (Boolean newPositiveSign,
+                                     Boolean newPrefixUpper,
                                      EIntegerBase newBase,
                                      Integer newPadding,
                                      Integer newSepEvery,
                                      Integer newSepSize,
                                      Boolean newSuffixUpper)
   {
-    return new IntegerRepresentation (newPrefixUpper == null ? prefixUpper : newPrefixUpper,
+    return new IntegerRepresentation (newPositiveSign == null ? positiveSign : newPositiveSign,
+                                      newPrefixUpper == null ? prefixUpper : newPrefixUpper,
                                       newBase == null ? base : newBase,
                                       newPadding == null ? padding : newPadding,
                                       newSepEvery == null ? separateEvery : newSepEvery,
@@ -130,12 +182,20 @@ public record IntegerRepresentation (
 
   public String format (int i)
   {
-    return base.represent (i, new StringBuilder (), prefixUpper, padding, separateEvery, separatorSize).toString ();
+    return base.represent (i, new StringBuilder (), positiveSign, prefixUpper, padding, separateEvery, separatorSize)
+               .toString ();
   }
 
   public String format (long l)
   {
-    return base.represent (l, new StringBuilder (), prefixUpper, padding, separateEvery, separatorSize, sufixUpper)
+    return base.represent (l,
+                           new StringBuilder (),
+                           positiveSign,
+                           prefixUpper,
+                           padding,
+                           separateEvery,
+                           separatorSize,
+                           sufixUpper)
                .toString ();
   }
 

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
@@ -1,5 +1,9 @@
 package com.helger.jcodemodel.literals;
 
+import java.util.Objects;
+
+import org.jspecify.annotations.NonNull;
+
 /// record containing the params to represent an int/long 
 /// 
 /// a representation is made of a prefix, a body, and a suffix 
@@ -13,6 +17,7 @@ public record IntegerRepresentation (
                                      /// if the base needs a prefix, should we uppercase it ?
                                      boolean prefixUpper,
                                      /// the base in which we want to represent the number, eg octal, binary
+                                     @NonNull
                                      IntegerBase base,
                                      /// if possible (not dec base), append 0 to make the representation's body at least   
                                      int padding,
@@ -22,8 +27,15 @@ public record IntegerRepresentation (
                                      /// number of "_" characters a separator string is made of.
                                      int separatorSize,
                                      /// if representing long, should we uppercase the terminal "l"
+                                     /// ?
                                      boolean sufixUpper)
 {
+
+  // validation
+  public IntegerRepresentation
+  {
+    Objects.requireNonNull (base);
+  }
 
   /// Default options are
   /// - lowercase the prefix, so "0x" instead of "0X"
@@ -71,6 +83,23 @@ public record IntegerRepresentation (
   public IntegerRepresentation sufixUpper (boolean sufixUpper)
   {
     return new IntegerRepresentation (prefixUpper, base, padding, separateEvery, separatorSize, sufixUpper);
+  }
+
+  /// @return new record with fields overwritten by non-null params.
+  /// This is present to avoid long chains of configuration when updating from a base model
+  public IntegerRepresentation with (Boolean newPrefixUpper,
+                                     IntegerBase newBase,
+                                     Integer newPadding,
+                                     Integer newSepEvery,
+                                     Integer newSepSize,
+                                     Boolean newSuffixUpper)
+  {
+    return new IntegerRepresentation (newPrefixUpper == null ? prefixUpper : newPrefixUpper,
+                                      newBase == null ? base : newBase,
+                                      newPadding == null ? padding : newPadding,
+                                      newSepEvery == null ? separateEvery : newSepEvery,
+                                      newSepSize == null ? separatorSize : newSepSize,
+                                      newSuffixUpper == null ? sufixUpper : newSuffixUpper);
   }
 
   //

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
@@ -19,10 +19,11 @@ public record IntegerRepresentation (
                                      boolean positiveSign,
                                      /// if the base needs a prefix, should we uppercase it ?
                                      boolean prefixUpper,
-                                     /// the base in which we want to represent the number, eg octal, binary
-                                     @NonNull
-                                     EIntegerBase base,
-                                     /// if possible (not dec base), append 0 to make the representation's body at least   
+                                     /// the base in which we want to represent the number, eg
+                                     /// octal, binary
+                                     @NonNull EIntegerBase base,
+                                     /// if possible (not dec base), append 0 to make the
+                                     /// representation's body at least
                                      int padding,
                                      /// how many characters to skip in the body before adding a
                                      /// separator String.
@@ -64,17 +65,26 @@ public record IntegerRepresentation (
                                                                                  1,
                                                                                  true);
 
-  /// print decimals with 3-chars separations, eg "1_000" or "1_234_567L"
-  public static final IntegerRepresentation DEC = DEFAULT.separateEvery (3);
-
   /// print binary with 8-chars separations, eg "1_00000000" or "1_00000000_00000000L"
   public static final IntegerRepresentation BIN = DEFAULT.with (null, null, EIntegerBase.BINARY, null, 8, null, null);
 
   /// bits with padding to 8 chars
   public static final IntegerRepresentation BIN8 = BIN.padding (8);
 
+  /// print decimals with 3-chars separations, eg "1_000" or "1_234_567L"
+  public static final IntegerRepresentation DEC = DEFAULT.separateEvery (3);
+
   // print hexa with 2-chars separations, eg "0xAA_BB"
-  public static final IntegerRepresentation HEX = DEFAULT.with (null, null, EIntegerBase.HEX, null, 2, null, null);
+  public static final IntegerRepresentation HEX = DEFAULT.with (null,
+                                                                null,
+                                                                EIntegerBase.HEXADECIMAL,
+                                                                null,
+                                                                2,
+                                                                null,
+                                                                null);
+
+  // print octal with 4-chars separations, eg "01_0000"
+  public static final IntegerRepresentation OCT = DEFAULT.with (null, null, EIntegerBase.OCTAL, null, 4, null, null);
 
   //
   // mutators
@@ -167,6 +177,16 @@ public record IntegerRepresentation (
                                      Integer newSepSize,
                                      Boolean newSuffixUpper)
   {
+    if ((newPositiveSign == null || newPositiveSign == positiveSign) &&
+      (newPrefixUpper == null || newPrefixUpper == prefixUpper) &&
+      (newBase == null || newBase == base) &&
+      (newPadding == null || newPadding == padding) &&
+      (newSepEvery == null || newSepEvery == separateEvery) &&
+      (newSepSize == null || newSepSize == separatorSize) &&
+      (newSuffixUpper == null || newSuffixUpper == sufixUpper))
+    {
+      return this;
+    }
     return new IntegerRepresentation (newPositiveSign == null ? positiveSign : newPositiveSign,
                                       newPrefixUpper == null ? prefixUpper : newPrefixUpper,
                                       newBase == null ? base : newBase,
@@ -195,8 +215,7 @@ public record IntegerRepresentation (
                            padding,
                            separateEvery,
                            separatorSize,
-                           sufixUpper)
-               .toString ();
+                           sufixUpper).toString ();
   }
 
 }

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
@@ -59,6 +59,7 @@ public record IntegerRepresentation (
   {
     public boolean positiveSign;
     public boolean prefixUpper;
+    @NonNull
     public EIntegerBase base;
     public boolean bodyUpper;
     public int padding;
@@ -173,7 +174,7 @@ public record IntegerRepresentation (
     return with (ir -> { ir.prefixUpper = prefixUpper; });
   }
 
-  public IntegerRepresentation base (EIntegerBase base)
+  public IntegerRepresentation base (@NonNull EIntegerBase base)
   {
     return with (ir -> { ir.base = base; });
   }

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
@@ -54,6 +54,15 @@ public class JAtomIntTest
       JAtomInt ia = new JAtomInt (8).separatorSize (1).separateEvery (3).binary ();
       Assert.assertEquals ("0b1_000", CodeModelTestsHelper.toString (ia));
     }
+
+    // padding
+    {
+      JAtomInt ia = new JAtomInt (42).separateEvery (0).padding (5);
+      Assert.assertEquals ("0b101010", CodeModelTestsHelper.toString (ia.binary ()));
+      Assert.assertEquals ("42", CodeModelTestsHelper.toString (ia.decimal ()));
+      Assert.assertEquals ("0x0002a", CodeModelTestsHelper.toString (ia.hex ()));
+      Assert.assertEquals ("000052", CodeModelTestsHelper.toString (ia.octal ()));
+    }
   }
 
 }

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
@@ -63,6 +63,21 @@ public class JAtomIntTest
       Assert.assertEquals ("0x0002a", CodeModelTestsHelper.toString (ia.hex ()));
       Assert.assertEquals ("000052", CodeModelTestsHelper.toString (ia.octal ()));
     }
+
+    // +sign , check that prefix/suffix lower/upper does not change a thing
+    {
+      JAtomInt ja = new JAtomInt (42);
+      for (boolean positiveSign : new boolean [] { true, false })
+        for (boolean prefixUpper : new boolean [] { true, false })
+        {
+          for (boolean suffixUpper : new boolean [] { true, false })
+          {
+            ja.representation (ja.representation ()
+                                 .with (positiveSign, prefixUpper, null, null, null, null, suffixUpper));
+            Assert.assertEquals (positiveSign ? "+42" : "42", CodeModelTestsHelper.toString (ja));
+          }
+        }
+    }
   }
 
 }

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
@@ -76,7 +76,7 @@ public class JAtomIntTest
         for (boolean suffixUpper : new boolean [] { true, false })
         {
           ja.representation (ja.representation ()
-                               .with (positiveSign, prefixUpper, null, null, null, null, suffixUpper));
+                               .with (positiveSign, prefixUpper, null, null, null, null, null, suffixUpper));
           Assert.assertEquals (positiveSign ? "+42" : "42", CodeModelTestsHelper.toString (ja));
         }
       }

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
@@ -76,7 +76,11 @@ public class JAtomIntTest
         for (boolean suffixUpper : new boolean [] { true, false })
         {
           ja.representation (ja.representation ()
-                               .with (positiveSign, prefixUpper, null, null, null, null, null, null, suffixUpper));
+                               .with (ir->{
+                                 ir.positiveSign=positiveSign;
+                                 ir.prefixUpper = prefixUpper;
+                                 ir.suffixUpper = suffixUpper;
+                               }));
           Assert.assertEquals (positiveSign ? "+42" : "42", CodeModelTestsHelper.toString (ja));
         }
       }

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
@@ -3,81 +3,83 @@ package com.helger.jcodemodel;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.helger.jcodemodel.literals.EIntegerBase;
+import com.helger.jcodemodel.literals.IntegerRepresentation;
 import com.helger.jcodemodel.util.CodeModelTestsHelper;
 
 public class JAtomIntTest
 {
   @Test
-  public void testRepresentation ()
+  public void testRepresentationDefault ()
   {
     // basic representation
     {
-      JAtomInt i42 = new JAtomInt (42).separateEvery (0);
+      JAtomInt i42 = new JAtomInt (42);
       Assert.assertEquals ("0b101010", CodeModelTestsHelper.toString (i42.binary ()));
       Assert.assertEquals ("42", CodeModelTestsHelper.toString (i42.decimal ()));
       Assert.assertEquals ("0x2a", CodeModelTestsHelper.toString (i42.hex ()));
       Assert.assertEquals ("052", CodeModelTestsHelper.toString (i42.octal ()));
     }
     {
-      JAtomInt i0 = new JAtomInt (0).separateEvery (0);
+      JAtomInt i0 = new JAtomInt (0);
       Assert.assertEquals ("0b0", CodeModelTestsHelper.toString (i0.binary ()));
       Assert.assertEquals ("0", CodeModelTestsHelper.toString (i0.decimal ()));
       Assert.assertEquals ("0x0", CodeModelTestsHelper.toString (i0.hex ()));
       Assert.assertEquals ("00", CodeModelTestsHelper.toString (i0.octal ()));
     }
     {
-      JAtomInt iNeg2 = new JAtomInt (-2).separateEvery (0);
+      JAtomInt iNeg2 = new JAtomInt (-2);
       Assert.assertEquals ("-0b10", CodeModelTestsHelper.toString (iNeg2.binary ()));
       Assert.assertEquals ("-2", CodeModelTestsHelper.toString (iNeg2.decimal ()));
       Assert.assertEquals ("-0x2", CodeModelTestsHelper.toString (iNeg2.hex ()));
       Assert.assertEquals ("-02", CodeModelTestsHelper.toString (iNeg2.octal ()));
     }
+  }
 
-    // separators
+  @Test
+  public void testRepresentationSeparator ()
+  {
     {
-      JAtomInt ia = new JAtomInt (-1234567).separatorSize (2).separateEvery (2).decimal ();
-      Assert.assertEquals ("-1__23__45__67", CodeModelTestsHelper.toString (ia));
+      IntegerRepresentation r = IntegerRepresentation.DEFAULT.separatorSize (2)
+                                                             .separateEvery (2)
+                                                             .base (EIntegerBase.DECIMAL);
+      Assert.assertEquals ("-1__23__45__67", CodeModelTestsHelper.toString (new JAtomInt (-1234567, r)));
+      Assert.assertEquals ("-12__34__56__78", CodeModelTestsHelper.toString (new JAtomInt (-12345678, r)));
     }
     {
-      JAtomInt ia = new JAtomInt (-12345678).separatorSize (2).separateEvery (2).decimal ();
-      Assert.assertEquals ("-12__34__56__78", CodeModelTestsHelper.toString (ia));
+      IntegerRepresentation r = IntegerRepresentation.DEFAULT.separatorSize (1)
+                                                             .separateEvery (3)
+                                                             .base (EIntegerBase.BINARY);
+      Assert.assertEquals ("-0b1_010", CodeModelTestsHelper.toString (new JAtomInt (-10, r)));
+      Assert.assertEquals ("0b100", CodeModelTestsHelper.toString (new JAtomInt (4, r)));
+      Assert.assertEquals ("0b1_000", CodeModelTestsHelper.toString (new JAtomInt (8, r)));
     }
-    {
-      JAtomInt ia = new JAtomInt (-10).separatorSize (1).separateEvery (3).binary ();
-      Assert.assertEquals ("-0b1_010", CodeModelTestsHelper.toString (ia));
-    }
-    {
-      JAtomInt ia = new JAtomInt (4).separatorSize (1).separateEvery (3).binary ();
-      Assert.assertEquals ("0b100", CodeModelTestsHelper.toString (ia));
-    }
-    {
-      JAtomInt ia = new JAtomInt (8).separatorSize (1).separateEvery (3).binary ();
-      Assert.assertEquals ("0b1_000", CodeModelTestsHelper.toString (ia));
-    }
+  }
 
-    // padding
-    {
-      JAtomInt ia = new JAtomInt (42).separateEvery (0).padding (5);
-      Assert.assertEquals ("0b101010", CodeModelTestsHelper.toString (ia.binary ()));
-      Assert.assertEquals ("42", CodeModelTestsHelper.toString (ia.decimal ()));
-      Assert.assertEquals ("0x0002a", CodeModelTestsHelper.toString (ia.hex ()));
-      Assert.assertEquals ("000052", CodeModelTestsHelper.toString (ia.octal ()));
-    }
+  @Test
+  public void testRepresentationPadding ()
+  {
+    JAtomInt ia = new JAtomInt (42).separateEvery (0).padding (5);
+    Assert.assertEquals ("0b101010", CodeModelTestsHelper.toString (ia.binary ()));
+    Assert.assertEquals ("42", CodeModelTestsHelper.toString (ia.decimal ()));
+    Assert.assertEquals ("0x0002a", CodeModelTestsHelper.toString (ia.hex ()));
+    Assert.assertEquals ("000052", CodeModelTestsHelper.toString (ia.octal ()));
+  }
 
-    // +sign , check that prefix/suffix lower/upper does not change a thing
-    {
-      JAtomInt ja = new JAtomInt (42);
-      for (boolean positiveSign : new boolean [] { true, false })
-        for (boolean prefixUpper : new boolean [] { true, false })
+  @Test
+  public void testRepresentationSign ()
+  {
+    JAtomInt ja = new JAtomInt (42);
+    for (boolean positiveSign : new boolean [] { true, false })
+      for (boolean prefixUpper : new boolean [] { true, false })
+      {
+        for (boolean suffixUpper : new boolean [] { true, false })
         {
-          for (boolean suffixUpper : new boolean [] { true, false })
-          {
-            ja.representation (ja.representation ()
-                                 .with (positiveSign, prefixUpper, null, null, null, null, suffixUpper));
-            Assert.assertEquals (positiveSign ? "+42" : "42", CodeModelTestsHelper.toString (ja));
-          }
+          ja.representation (ja.representation ()
+                               .with (positiveSign, prefixUpper, null, null, null, null, suffixUpper));
+          Assert.assertEquals (positiveSign ? "+42" : "42", CodeModelTestsHelper.toString (ja));
         }
-    }
+      }
   }
 
 }

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
@@ -17,7 +17,7 @@ public class JAtomIntTest
       JAtomInt i42 = new JAtomInt (42);
       Assert.assertEquals ("0b101010", CodeModelTestsHelper.toString (i42.binary ()));
       Assert.assertEquals ("42", CodeModelTestsHelper.toString (i42.decimal ()));
-      Assert.assertEquals ("0x2a", CodeModelTestsHelper.toString (i42.hexadecimal ()));
+      Assert.assertEquals ("0x2A", CodeModelTestsHelper.toString (i42.hexadecimal ()));
       Assert.assertEquals ("052", CodeModelTestsHelper.toString (i42.octal ()));
     }
     {
@@ -62,7 +62,7 @@ public class JAtomIntTest
     JAtomInt ia = new JAtomInt (42).separateEvery (0).padding (5);
     Assert.assertEquals ("0b101010", CodeModelTestsHelper.toString (ia.binary ()));
     Assert.assertEquals ("42", CodeModelTestsHelper.toString (ia.decimal ()));
-    Assert.assertEquals ("0x0002a", CodeModelTestsHelper.toString (ia.hexadecimal ()));
+    Assert.assertEquals ("0x0002A", CodeModelTestsHelper.toString (ia.hexadecimal ()));
     Assert.assertEquals ("000052", CodeModelTestsHelper.toString (ia.octal ()));
   }
 
@@ -76,7 +76,7 @@ public class JAtomIntTest
         for (boolean suffixUpper : new boolean [] { true, false })
         {
           ja.representation (ja.representation ()
-                               .with (positiveSign, prefixUpper, null, null, null, null, null, suffixUpper));
+                               .with (positiveSign, prefixUpper, null, null, null, null, null, null, suffixUpper));
           Assert.assertEquals (positiveSign ? "+42" : "42", CodeModelTestsHelper.toString (ja));
         }
       }

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomIntTest.java
@@ -17,21 +17,21 @@ public class JAtomIntTest
       JAtomInt i42 = new JAtomInt (42);
       Assert.assertEquals ("0b101010", CodeModelTestsHelper.toString (i42.binary ()));
       Assert.assertEquals ("42", CodeModelTestsHelper.toString (i42.decimal ()));
-      Assert.assertEquals ("0x2a", CodeModelTestsHelper.toString (i42.hex ()));
+      Assert.assertEquals ("0x2a", CodeModelTestsHelper.toString (i42.hexadecimal ()));
       Assert.assertEquals ("052", CodeModelTestsHelper.toString (i42.octal ()));
     }
     {
       JAtomInt i0 = new JAtomInt (0);
       Assert.assertEquals ("0b0", CodeModelTestsHelper.toString (i0.binary ()));
       Assert.assertEquals ("0", CodeModelTestsHelper.toString (i0.decimal ()));
-      Assert.assertEquals ("0x0", CodeModelTestsHelper.toString (i0.hex ()));
+      Assert.assertEquals ("0x0", CodeModelTestsHelper.toString (i0.hexadecimal ()));
       Assert.assertEquals ("00", CodeModelTestsHelper.toString (i0.octal ()));
     }
     {
       JAtomInt iNeg2 = new JAtomInt (-2);
       Assert.assertEquals ("-0b10", CodeModelTestsHelper.toString (iNeg2.binary ()));
       Assert.assertEquals ("-2", CodeModelTestsHelper.toString (iNeg2.decimal ()));
-      Assert.assertEquals ("-0x2", CodeModelTestsHelper.toString (iNeg2.hex ()));
+      Assert.assertEquals ("-0x2", CodeModelTestsHelper.toString (iNeg2.hexadecimal ()));
       Assert.assertEquals ("-02", CodeModelTestsHelper.toString (iNeg2.octal ()));
     }
   }
@@ -62,7 +62,7 @@ public class JAtomIntTest
     JAtomInt ia = new JAtomInt (42).separateEvery (0).padding (5);
     Assert.assertEquals ("0b101010", CodeModelTestsHelper.toString (ia.binary ()));
     Assert.assertEquals ("42", CodeModelTestsHelper.toString (ia.decimal ()));
-    Assert.assertEquals ("0x0002a", CodeModelTestsHelper.toString (ia.hex ()));
+    Assert.assertEquals ("0x0002a", CodeModelTestsHelper.toString (ia.hexadecimal ()));
     Assert.assertEquals ("000052", CodeModelTestsHelper.toString (ia.octal ()));
   }
 

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomLongTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomLongTest.java
@@ -1,0 +1,20 @@
+package com.helger.jcodemodel;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.helger.jcodemodel.literals.IntegerRepresentation;
+import com.helger.jcodemodel.util.CodeModelTestsHelper;
+
+public class JAtomLongTest
+{
+
+  @Test
+  public void testRepresentationBasic ()
+  {
+    Assert.assertEquals ("42L", CodeModelTestsHelper.toString (new JAtomLong (42, IntegerRepresentation.DEC)));
+    Assert.assertEquals ("0x2aL", CodeModelTestsHelper.toString (new JAtomLong (42, IntegerRepresentation.HEX)));
+    Assert.assertEquals ("-052L", CodeModelTestsHelper.toString (new JAtomLong (-42, IntegerRepresentation.OCT)));
+  }
+
+}

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomLongTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomLongTest.java
@@ -16,7 +16,7 @@ public class JAtomLongTest
     Assert.assertEquals ("0b1_00000001L",
                          CodeModelTestsHelper.toString (new JAtomLong (257, IntegerRepresentation.BIN)));
     Assert.assertEquals ("1_024L", CodeModelTestsHelper.toString (new JAtomLong (1024, IntegerRepresentation.DEC)));
-    Assert.assertEquals ("0x2aL", CodeModelTestsHelper.toString (new JAtomLong (42, IntegerRepresentation.HEX)));
+    Assert.assertEquals ("0x2AL", CodeModelTestsHelper.toString (new JAtomLong (42, IntegerRepresentation.HEX)));
     Assert.assertEquals ("-052L", CodeModelTestsHelper.toString (new JAtomLong (-42, IntegerRepresentation.OCT)));
   }
 

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomLongTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/JAtomLongTest.java
@@ -12,7 +12,10 @@ public class JAtomLongTest
   @Test
   public void testRepresentationBasic ()
   {
-    Assert.assertEquals ("42L", CodeModelTestsHelper.toString (new JAtomLong (42, IntegerRepresentation.DEC)));
+    Assert.assertEquals ("42L", CodeModelTestsHelper.toString (new JAtomLong (42, IntegerRepresentation.DEFAULT)));
+    Assert.assertEquals ("0b1_00000001L",
+                         CodeModelTestsHelper.toString (new JAtomLong (257, IntegerRepresentation.BIN)));
+    Assert.assertEquals ("1_024L", CodeModelTestsHelper.toString (new JAtomLong (1024, IntegerRepresentation.DEC)));
     Assert.assertEquals ("0x2aL", CodeModelTestsHelper.toString (new JAtomLong (42, IntegerRepresentation.HEX)));
     Assert.assertEquals ("-052L", CodeModelTestsHelper.toString (new JAtomLong (-42, IntegerRepresentation.OCT)));
   }

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/literals/EIntegerBaseTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/literals/EIntegerBaseTest.java
@@ -1,0 +1,32 @@
+package com.helger.jcodemodel.literals;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EIntegerBaseTest
+{
+
+  void testFormat (String expected, String source, String format, boolean allowLeadingSep)
+  {
+    StringBuilder sb = new StringBuilder ();
+    EIntegerBase.addSep (source, format, allowLeadingSep, 0, 0, sb);
+    Assert.assertEquals (expected, sb.toString ());
+  }
+
+  @Test
+  public void addSep ()
+  {
+    {
+      testFormat ("_0", "0", "_ ", true);
+      testFormat ("__0", "0", "__ ", true);
+      testFormat ("0", "0", "__ ", false);
+      testFormat ("012__3", "0123", "__ ", true);
+      testFormat ("_0_12_3", "0123", "_c_cc_c", true);
+      testFormat ("0_12_3", "0123", "_c_cc_c", false);
+      testFormat ("01__2_3", "0123", "__ _ ", true);
+      testFormat ("01__2_3", "0123", "__ __", true);
+      testFormat ("01234_56_789", "0123456789", "_  _   ", true);
+    }
+  }
+
+}

--- a/jcodemodel/src/test/java/com/helger/jcodemodel/literals/EIntegerBaseTest.java
+++ b/jcodemodel/src/test/java/com/helger/jcodemodel/literals/EIntegerBaseTest.java
@@ -6,26 +6,31 @@ import org.junit.Test;
 public class EIntegerBaseTest
 {
 
-  void testFormat (String expected, String source, String format, boolean allowLeadingSep)
+  static void checkFormat (String expected, String source, String format, boolean allowLeadingSep)
   {
     StringBuilder sb = new StringBuilder ();
     EIntegerBase.addSep (source, format, allowLeadingSep, 0, 0, sb);
     Assert.assertEquals (expected, sb.toString ());
   }
 
+  /// some tests on adding separators to an int representation using [EIntegerBase#addSep]
   @Test
-  public void addSep ()
+  public void testAddSep ()
   {
     {
-      testFormat ("_0", "0", "_ ", true);
-      testFormat ("__0", "0", "__ ", true);
-      testFormat ("0", "0", "__ ", false);
-      testFormat ("012__3", "0123", "__ ", true);
-      testFormat ("_0_12_3", "0123", "_c_cc_c", true);
-      testFormat ("0_12_3", "0123", "_c_cc_c", false);
-      testFormat ("01__2_3", "0123", "__ _ ", true);
-      testFormat ("01__2_3", "0123", "__ __", true);
-      testFormat ("01234_56_789", "0123456789", "_  _   ", true);
+      checkFormat ("_0", "0", "_ ", true);
+      checkFormat ("__0", "0", "__ ", true);
+      checkFormat ("0", "0", "__ ", false);
+      checkFormat ("012__3", "0123", "__ ", true);
+
+      checkFormat ("_0_12_3", "0123", "_c_cc_c", true);
+      checkFormat ("0_12_3", "0123", "_c_cc_c", false);
+      checkFormat ("___0_12_3", "0123", "___c_cc_c", true);
+      checkFormat ("0_12_3", "0123", "___c_cc_c", false);
+
+      checkFormat ("01__2_3", "0123", "__d_d", true);
+      checkFormat ("01__2_3", "0123", "__d__", true);
+      checkFormat ("01234_56_789", "0123456789", "_dd_ddd", true);
     }
   }
 

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/intformat/FormatIntWithSeparatorEvery0Size1.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/intformat/FormatIntWithSeparatorEvery0Size1.java
@@ -30,4 +30,8 @@ public class FormatIntWithSeparatorEvery0Size1 {
     public static final int iNeg1kd = -1024;
     public static final int iNeg1kh = -0x400;
     public static final int iNeg1ko = -02000;
+    public static final int i42p5b = 0b101010;
+    public static final int i42p5d = 42;
+    public static final int i42p5h = 0x0002a;
+    public static final int i42p5o = 000052;
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/intformat/FormatIntWithSeparatorEvery0Size1.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/intformat/FormatIntWithSeparatorEvery0Size1.java
@@ -32,6 +32,6 @@ public class FormatIntWithSeparatorEvery0Size1 {
     public static final int iNeg1ko = -02000;
     public static final int i42p5b = 0b101010;
     public static final int i42p5d = 42;
-    public static final int i42p5h = 0x0002a;
+    public static final int i42p5h = 0x0002A;
     public static final int i42p5o = 000052;
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/intformat/FormatIntWithSeparatorEvery2Size2.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/intformat/FormatIntWithSeparatorEvery2Size2.java
@@ -30,4 +30,8 @@ public class FormatIntWithSeparatorEvery2Size2 {
     public static final int iNeg1kd = -10__24;
     public static final int iNeg1kh = -0x4__00;
     public static final int iNeg1ko = -020__00;
+    public static final int i42p5b = 0b10__10__10;
+    public static final int i42p5d = 42;
+    public static final int i42p5h = 0x0__00__2a;
+    public static final int i42p5o = 00__00__52;
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/intformat/FormatIntWithSeparatorEvery2Size2.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/intformat/FormatIntWithSeparatorEvery2Size2.java
@@ -32,6 +32,6 @@ public class FormatIntWithSeparatorEvery2Size2 {
     public static final int iNeg1ko = -020__00;
     public static final int i42p5b = 0b10__10__10;
     public static final int i42p5d = 42;
-    public static final int i42p5h = 0x0__00__2a;
+    public static final int i42p5h = 0x0__00__2A;
     public static final int i42p5o = 00__00__52;
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/intformat/FormatIntWithSeparatorEvery3Size1.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/intformat/FormatIntWithSeparatorEvery3Size1.java
@@ -30,4 +30,8 @@ public class FormatIntWithSeparatorEvery3Size1 {
     public static final int iNeg1kd = -1_024;
     public static final int iNeg1kh = -0x400;
     public static final int iNeg1ko = -02_000;
+    public static final int i42p5b = 0b101_010;
+    public static final int i42p5d = 42;
+    public static final int i42p5h = 0x00_02a;
+    public static final int i42p5o = 000_052;
 }

--- a/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/intformat/FormatIntWithSeparatorEvery3Size1.java
+++ b/jcodemodeltests/src/generated/javatest/com/helger/jcodemodel/tests/intformat/FormatIntWithSeparatorEvery3Size1.java
@@ -32,6 +32,6 @@ public class FormatIntWithSeparatorEvery3Size1 {
     public static final int iNeg1ko = -02_000;
     public static final int i42p5b = 0b101_010;
     public static final int i42p5d = 42;
-    public static final int i42p5h = 0x00_02a;
+    public static final int i42p5h = 0x00_02A;
     public static final int i42p5o = 000_052;
 }

--- a/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/intformat/IntFormatTestGen.java
+++ b/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/intformat/IntFormatTestGen.java
@@ -37,6 +37,15 @@ public class IntFormatTestGen {
         JExpr.lit(-1024).hex().separateEvery(separateEvery).separatorSize(sepSize));
     clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "iNeg1ko",
         JExpr.lit(-1024).octal().separateEvery(separateEvery).separatorSize(sepSize));
+
+    clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "i42p5b",
+        JExpr.lit(42).binary().separateEvery(separateEvery).separatorSize(sepSize).padding(5));
+    clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "i42p5d",
+        JExpr.lit(42).decimal().separateEvery(separateEvery).separatorSize(sepSize).padding(5));
+    clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "i42p5h",
+        JExpr.lit(42).hex().separateEvery(separateEvery).separatorSize(sepSize).padding(5));
+    clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "i42p5o",
+        JExpr.lit(42).octal().separateEvery(separateEvery).separatorSize(sepSize).padding(5));
   }
 
   static void generate(JPackage root, int separateEvery, int sepSize) throws JCodeModelException {

--- a/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/intformat/IntFormatTestGen.java
+++ b/jcodemodeltests/src/main/java/com/helger/jcodemodel/tests/intformat/IntFormatTestGen.java
@@ -16,7 +16,7 @@ public class IntFormatTestGen {
     clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "i32d",
         JExpr.lit(32).decimal().separateEvery(separateEvery).separatorSize(sepSize));
     clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "i32h",
-        JExpr.lit(32).hex().separateEvery(separateEvery).separatorSize(sepSize));
+        JExpr.lit(32).hexadecimal().separateEvery(separateEvery).separatorSize(sepSize));
     clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "i32o",
         JExpr.lit(32).octal().separateEvery(separateEvery).separatorSize(sepSize));
 
@@ -25,7 +25,7 @@ public class IntFormatTestGen {
     clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "i1Md",
         JExpr.lit(1024 * 1024).decimal().separateEvery(separateEvery).separatorSize(sepSize));
     clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "i1Mh",
-        JExpr.lit(1024 * 1024).hex().separateEvery(separateEvery).separatorSize(sepSize));
+        JExpr.lit(1024 * 1024).hexadecimal().separateEvery(separateEvery).separatorSize(sepSize));
     clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "i1Mo",
         JExpr.lit(1024 * 1024).octal().separateEvery(separateEvery).separatorSize(sepSize));
 
@@ -34,7 +34,7 @@ public class IntFormatTestGen {
     clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "iNeg1kd",
         JExpr.lit(-1024).decimal().separateEvery(separateEvery).separatorSize(sepSize));
     clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "iNeg1kh",
-        JExpr.lit(-1024).hex().separateEvery(separateEvery).separatorSize(sepSize));
+        JExpr.lit(-1024).hexadecimal().separateEvery(separateEvery).separatorSize(sepSize));
     clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "iNeg1ko",
         JExpr.lit(-1024).octal().separateEvery(separateEvery).separatorSize(sepSize));
 
@@ -43,7 +43,7 @@ public class IntFormatTestGen {
     clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "i42p5d",
         JExpr.lit(42).decimal().separateEvery(separateEvery).separatorSize(sepSize).padding(5));
     clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "i42p5h",
-        JExpr.lit(42).hex().separateEvery(separateEvery).separatorSize(sepSize).padding(5));
+        JExpr.lit(42).hexadecimal().separateEvery(separateEvery).separatorSize(sepSize).padding(5));
     clazz.field(JMod.PUBLIC_STATIC_FINAL, clazz.owner().INT, "i42p5o",
         JExpr.lit(42).octal().separateEvery(separateEvery).separatorSize(sepSize).padding(5));
   }


### PR DESCRIPTION
# Objective, constraints and explanations

A previous PR already embarked the "base" feature, but this one is cleaner/more detailed, especially regarding sharing settings.

This PR aims at providing ways to represent integer/long format in the generated code.

When we want to write an int, for example "404", with `JExpr.lit(404)` , we may also want to specify how this value will be written in the resulting code, eg
1. the base :  "404" in decimal, "0624" in octal, "0x194" in hexadecimal
2. add the positive leading sign , so "+404"
3. padd for non-decimal base as in "0x00000194"
4. in the case of hex should we upper/lower case the letters and the "x" in the prefix ?
5. Then should we add "_" separators, and where ?

In short, "+4_0_4" is just as valid as "0000624".
This set of choices is a "representation" of integers. It's not in the formatting settings, because formatting is project-wide, while those can change on a class or even field basis.

The main use case of those representations are defining them, and using them in int/long fields (a long is just an int with tailing l/L), therefore the building of one received special attention, with default representations available, both to use directly or to be based on.
As constraints, the default representation of an int should produce the same, when possible, as before ; and should impend no performance hit. 

Since creating user-specific representation should not modify the default values, they are all records to be read only. Updating a representation's value actually create a new representation with that value updated. The JAtomInt and JAtomLong can be set their representation, and provide a few methods to update specific fields though it replaces the internal representation with an updated copy.

Those representation start with a base, for example octal, then add options, in the order : force positive sign, padding, use lower caps letters, use separators.


# Features

## Format class

A new `IntegerRepresentation` record contains information to represent int and long in the code.

### Creation

A few default representation are available ; you are recommended to create your own that you use in your own library, since the default ones are not designed to be core part of the lib (they are arbitrary choices so not as stable as choice presentation).


```java
// creation

// use default one, no separator
IntegerRepresentation myIR = IntegerRepresentation.DEFAULT;

// or default decimal one eg 1_000_000L
myIR = IntegerRepresentation.DEC;

// default hexa so 0xAB_CDL
myIR = IntegerRepresentation.HEX;

//specify all params
myIR = new IntegerRepresentation (false,
                                                                                 false,
                                                                                 EIntegerBase.DECIMAL,
                                                                                 0,
                                                                                 null,
                                                                                 0,
                                                                                 1,
                                                                                 true);
```


### Usage

JAtomInteger and JAtomLong have that new field. They extend a common class that allows to manipulate those fields internally, replacing the representation each time.

```java
// usage

var i = new JAtomInt(42, myIR);
i = new JAtomInt(42).representation(myIR)
// change the base to octal
i.octal()
// and add a separator every 3 char
.separateEvery(3)
// force the addition of +
.positiveSign(true);
```

### Formatting process

1. formatting an integer/long uses a base and creates sign, prefix, body, suffix
7. sign only present if negative value or representation's `positiveSign` is true 
8. prefix depends on the base selected. The representation's `prefixUpper` indicates if use upper or lower case prefix
9. body is converted from the base , then padded , then separated
10. suffix is only for LONG .  The representation's `suffixUpper` indicates if use 'L' or 'l'
11. padded only applied for bases that use it. Decimal does not allow padding.
12. body separation is either performed with a separator format, or if null using the `separateEvery` and `separateSize` fields.
13. separator format indicates before which char, and how many, separators to add : each '_' indicates one separator to insert, starting from the end.
14. separateEvery indicates after how many body chars to add separator, and separateSize how many separator each time.

### Padding example

(those are the tests)

42 padded 5 is
 - 0b101010 (no padding needed here)
 - 42 (can't pad decimal)
 - 0x0002a (padding in hex)
 - 000052  (padding in octal)

###  Separator Format example

1000 decimal with format : 
 - "X_X" produces "100_0" : only adds a separator before the before-last charater
 - "_xx__x" produces "1_00__0"