### PR TITLE
"generate source" mojo iterates over the files if source is a dir.

### DIFF
--- a/examples/plugins/yaml/concreteYaml/concreteList.yaml
+++ b/examples/plugins/yaml/concreteYaml/concreteList.yaml
@@ -21,9 +21,3 @@ package: # we add getters and setters on all field of the package
     
 ConcreteList:
    extends: "object list list" 
-    
-ConcreteMap:
-   extends: "string map" 
-    
-ConcreteSet:
-   extends: "object list set" 

--- a/examples/plugins/yaml/concreteYaml/concreteMap.yaml
+++ b/examples/plugins/yaml/concreteYaml/concreteMap.yaml
@@ -1,0 +1,6 @@
+package: # we add getters and setters on all field of the package
+   - get
+   - set
+    
+ConcreteMap:
+   extends: "string map" 

--- a/examples/plugins/yaml/concreteYaml/concreteSet.yaml
+++ b/examples/plugins/yaml/concreteYaml/concreteSet.yaml
@@ -1,0 +1,6 @@
+package: # we add getters and setters on all field of the package
+   - get
+   - set
+    
+ConcreteSet:
+   extends: "object list set" 

--- a/examples/plugins/yaml/concreteYaml/invalidOnPurpose.txt
+++ b/examples/plugins/yaml/concreteYaml/invalidOnPurpose.txt
@@ -1,0 +1,1 @@
+file only present to be sure it is filtered out by the plugin's filter ".yaml".  

--- a/examples/plugins/yaml/pom.xml
+++ b/examples/plugins/yaml/pom.xml
@@ -65,7 +65,7 @@ limitations under the License.
               <goal>generate-source</goal>
             </goals>
             <configuration>
-              <source>sourceConcrete.yaml</source>
+              <source>concreteYaml</source>
               <rootPackage>com.helger.jcodemodel.examples.plugin.yaml.concrete</rootPackage>
               <params>
                 <concrete.list>LinkedList</concrete.list>

--- a/examples/plugins/yaml/pom.xml
+++ b/examples/plugins/yaml/pom.xml
@@ -66,6 +66,7 @@ limitations under the License.
             </goals>
             <configuration>
               <source>concreteYaml</source>
+              <sourcesFilter>.yaml</sourcesFilter>
               <rootPackage>com.helger.jcodemodel.examples.plugin.yaml.concrete</rootPackage>
               <params>
                 <concrete.list>LinkedList</concrete.list>

--- a/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/GenerateSourceMojo.java
+++ b/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/GenerateSourceMojo.java
@@ -16,11 +16,14 @@ package com.helger.jcodemodel.plugin.maven;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -141,13 +144,24 @@ public class GenerateSourceMojo extends AbstractMojo
     {
       getLog ().warn ("discarding source param " + m_sSource + " as data is already set");
     }
-    try (final InputStream aIS = StringHelper.isEmpty (m_sData) ? findSource ()
-                                                                : new NonBlockingByteArrayInputStream (m_sData.getBytes (StandardCharsets.UTF_8)))
+    Stream <? extends InputStream> sis = (StringHelper.isEmpty (m_sData)) ? findSource ()
+                                                                          : Stream.of (new NonBlockingByteArrayInputStream (m_sData.getBytes (StandardCharsets.UTF_8)));
+    for (InputStream is : sis.toList ())
     {
-      cmb.build (cm, aIS);
+      try (is)
+      {
+        cmb.build (cm, is);
+      }
+      catch (JCodeModelException | IOException e)
+      {
+        throw new MojoFailureException (e);
+      }
+    }
+    try
+    {
       new JCMWriter (cm).setJavaFeature (findJavaFeature ()).build (dir, (IProgressTracker) null);
     }
-    catch (JCodeModelException | IOException e)
+    catch (IOException e)
     {
       throw new MojoFailureException (e);
     }
@@ -177,9 +191,10 @@ public class GenerateSourceMojo extends AbstractMojo
     if (sGeneratorClass == null)
       sGeneratorClass = findGeneratorClass ();
 
-    return StringHelper.isEmpty (sGeneratorClass) ? null : (ICodeModelBuilder) Class.forName (sGeneratorClass)
-                                                                                    .getDeclaredConstructor ()
-                                                                                    .newInstance ();
+    return StringHelper.isEmpty (sGeneratorClass) ? null
+                                                  : (ICodeModelBuilder) Class.forName (sGeneratorClass)
+                                                                             .getDeclaredConstructor ()
+                                                                             .newInstance ();
   }
 
   @Nullable
@@ -198,35 +213,83 @@ public class GenerateSourceMojo extends AbstractMojo
     }
   }
 
-  @Nullable
-  protected InputStream findSource () throws MojoExecutionException
+  /// Extract the inputstreams from the specified source.
+  ///
+  /// - null is returned as a stream containing null
+  /// - A directory string is recursively streamed over its files
+  /// - A single file String is opened as a single-element stream
+  /// - A url string is opened it as a stream
+  /// - otherwise, as for example file not found, exception is thrown
+  ///
+  /// @return extracted input streams if success, Stream of null if no source.
+  /// @throws MojoExecutionException if can't open the source as a file nor an url.
+  @NonNull
+  protected Stream <InputStream> findSource () throws MojoExecutionException
   {
     if (m_sSource == null || m_sSource.isBlank ())
-      return null;
-
+      return Stream.of ((InputStream) null);
     // dumb checking : is it a file ? a URL ?
+
+    // store the file exception, only show it if url also fails
+    Exception fileException = null;
     try
     {
       final File aTargetFile = m_sSource.startsWith ("/") ? new File (m_sSource)
                                                           : new File (m_aProject.getBasedir (), m_sSource);
-      return new FileInputStream (aTargetFile);
+
+      return streamFiles (aTargetFile);
     }
     catch (final Exception e)
     {
-      getLog ().info ("while trying to open " + m_sSource + " as a file", e);
+      fileException = e;
     }
 
     try
     {
       final URL aURL = new URL (m_sSource);
-      return aURL.openStream ();
+      return Stream.of (aURL.openStream ());
     }
     catch (final IOException e)
     {
-      getLog ().info ("while trying to open " + m_sSource + " as a url", e);
+      getLog ().error ("while trying to open " + m_sSource + " as a file", fileException);
+      getLog ().error ("while trying to open " + m_sSource + " as a url", e);
     }
 
     throw new MojoExecutionException ("could not open provided source " + m_sSource + " as a file or url");
+  }
+
+  /**
+   * recursively stream the files inside the file.
+   * 
+   * @param rootFile
+   *        file to browse
+   * @return a single inputstream of the file if it is a normal file. inputstreams of its children
+   *         if it is a dir. Otherwise, return empty stream.
+   */
+  @NonNull
+  protected Stream <InputStream> streamFiles (File rootFile)
+  {
+    if (rootFile.isFile ())
+    {
+      try
+      {
+        return Stream.of (new FileInputStream (rootFile));
+      }
+      catch (FileNotFoundException e)
+      {
+        // should never happens since isFile checks for existence
+        throw new RuntimeException (e);
+      }
+    }
+    else
+      if (!rootFile.isDirectory ())
+      {
+        return Stream.of ();
+      }
+      else // file is directory
+        return Stream.of (rootFile.listFiles ())
+                     .sorted (Comparator.comparing (File::getPath))
+                     .flatMap (this::streamFiles);
   }
 
   /**

--- a/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/GenerateSourceMojo.java
+++ b/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/GenerateSourceMojo.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -69,6 +70,11 @@ public class GenerateSourceMojo extends AbstractMojo
    */
   @Parameter (name = "source", property = "jcodemodel.source")
   private String m_sSource;
+
+  /// if the source is a directory, and this param is not null/empty, then only files with a last
+  /// name containing this (ignoring case) will be selected as generator sources
+  @Parameter (name = "sourcesFilter", property = "jcodemodel.sourcesFilter", required = false)
+  private String sourcesFilter;
 
   /**
    * Java feature (major release version) the generated class files are targeted at. When unset the
@@ -144,7 +150,7 @@ public class GenerateSourceMojo extends AbstractMojo
     {
       getLog ().warn ("discarding source param " + m_sSource + " as data is already set");
     }
-    Stream <? extends InputStream> sis = (StringHelper.isEmpty (m_sData)) ? findSource ()
+    Stream <? extends InputStream> sis = (StringHelper.isEmpty (m_sData)) ? findSources ()
                                                                           : Stream.of (new NonBlockingByteArrayInputStream (m_sData.getBytes (StandardCharsets.UTF_8)));
     for (InputStream is : sis.toList ())
     {
@@ -224,7 +230,7 @@ public class GenerateSourceMojo extends AbstractMojo
   /// @return extracted input streams if success, Stream of null if no source.
   /// @throws MojoExecutionException if can't open the source as a file nor an url.
   @NonNull
-  protected Stream <InputStream> findSource () throws MojoExecutionException
+  protected Stream <InputStream> findSources () throws MojoExecutionException
   {
     if (m_sSource == null || m_sSource.isBlank ())
       return Stream.of ((InputStream) null);
@@ -236,7 +242,6 @@ public class GenerateSourceMojo extends AbstractMojo
     {
       final File aTargetFile = m_sSource.startsWith ("/") ? new File (m_sSource)
                                                           : new File (m_aProject.getBasedir (), m_sSource);
-
       return streamFiles (aTargetFile);
     }
     catch (final Exception e)
@@ -288,6 +293,9 @@ public class GenerateSourceMojo extends AbstractMojo
       }
       else // file is directory
         return Stream.of (rootFile.listFiles ())
+                     .filter (f -> sourcesFilter == null ||
+                       sourcesFilter.isBlank () ||
+                       f.getName ().toLowerCase (Locale.getDefault ()).contains (sourcesFilter.toLowerCase ()))
                      .sorted (Comparator.comparing (File::getPath))
                      .flatMap (this::streamFiles);
   }

--- a/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/GenerateSourceMojo.java
+++ b/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/GenerateSourceMojo.java
@@ -295,7 +295,9 @@ public class GenerateSourceMojo extends AbstractMojo
         return Stream.of (rootFile.listFiles ())
                      .filter (f -> sourcesFilter == null ||
                        sourcesFilter.isBlank () ||
-                       f.getName ().toLowerCase (Locale.getDefault ()).contains (sourcesFilter.toLowerCase ()))
+                       f.getName ()
+                        .toLowerCase (Locale.ROOT)
+                        .contains (sourcesFilter.toLowerCase (Locale.ROOT)))
                      .sorted (Comparator.comparing (File::getPath))
                      .flatMap (this::streamFiles);
   }

--- a/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/ICodeModelBuilder.java
+++ b/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/ICodeModelBuilder.java
@@ -41,18 +41,19 @@ public interface ICodeModelBuilder
 
   /**
    * @param header
-   *        The class header to be used. May be <code>null</code>.
+   *        The class header (comment) to be used. May be <code>null</code>.
    */
   default void setClassHeader (@Nullable final String header)
   {}
 
   /**
-   * asking the generator to build a model.
+   * alter a model according to the specifications in a source.
    *
    * @param model
    *        the model to build into.
    * @param source
-   *        inputstream deduced by the plugin. May be <code>null</code>.
+   *        inputstream deduced by the plugin. May be <code>null</code>, in which case most
+   *        generators would do nothing ; but this allows to have static generators.
    * @throws JCodeModelException
    *         in case of creation error
    */
@@ -74,9 +75,12 @@ public interface ICodeModelBuilder
   @Nullable
   String getRootPackage ();
 
+  /** transmitted by the plugin, specifies when set in which package to add the classes */
   void setRootPackage (@Nullable String rootPackage);
 
   /**
+   * transform a relative path into absolute by using the rootPackage.
+   * 
    * @param localPath
    *        class we want to create, eg "pck.MyClass"
    * @return localpath prefixed by rootpackage and "." if needed.


### PR DESCRIPTION
The plugin can now be configured with a directory rather than an url / single file

In the example module, the pom references the `concreteYaml` directory to generate some trivial concrete classes, before the files in that directory were in a single one.

```xml
            <configuration>
              <source>concreteYaml</source> <!-- << here -->
              <rootPackage>com.helger.jcodemodel.examples.plugin.yaml.concrete</rootPackage>
```

This is done at the plugin level so generators should not be changed.

When a dir is found, all the files in it are applied to the generator, on the same JCM which is exported at the end. Therefore, each file must be valid on their own, and should not reference type from another one.

Also more docs for api.

No change is applied otherwise, and it only *allows* to use directory, so previous behavor did not change