### PR TITLE
keep inputstream source when generating from the plugin

### DIFF
--- a/plugin/generators/csv/src/main/java/com/helger/jcodemodel/plugin/generators/csv/CSVGenerator.java
+++ b/plugin/generators/csv/src/main/java/com/helger/jcodemodel/plugin/generators/csv/CSVGenerator.java
@@ -15,7 +15,6 @@
 package com.helger.jcodemodel.plugin.generators.csv;
 
 import java.io.BufferedReader;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -24,6 +23,7 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import com.helger.base.string.StringHelper;
+import com.helger.jcodemodel.plugin.maven.ISourcedInputStream;
 import com.helger.jcodemodel.plugin.maven.generators.AbstractFlatStructureGenerator;
 import com.helger.jcodemodel.plugin.maven.generators.JCMGen;
 import com.helger.jcodemodel.plugin.maven.generators.flatstruct.FieldOptions;
@@ -44,11 +44,15 @@ public class CSVGenerator extends AbstractFlatStructureGenerator
     fldSep = params.getOrDefault ("field_sep", fldSep);
   }
 
+  @SuppressWarnings("resource")
   @Override
-  protected Stream <IFlatStructRecord> loadSource (final InputStream source)
+  protected Stream<IFlatStructRecord> loadSource(final ISourcedInputStream source)
   {
     // What charset to use?
-    return new BufferedReader (new InputStreamReader (source)).lines ().map (this::convertLine).filter (r -> r != null);
+    return new BufferedReader(new InputStreamReader(source.inputStream()))
+        .lines()
+        .map(this::convertLine)
+        .filter(r -> r != null);
   }
 
   @Nullable
@@ -60,8 +64,9 @@ public class CSVGenerator extends AbstractFlatStructureGenerator
     }
     final String [] spl = line.trim ().split (fldSep);
     final String className = spl[0].trim ();
-    if (StringHelper.isEmpty (className))
+    if (StringHelper.isEmpty (className)) {
       return null;
+    }
 
     // field name for fields. Absent for non-fields
 
@@ -91,8 +96,9 @@ public class CSVGenerator extends AbstractFlatStructureGenerator
     // no field name specified : class or package definition
     if (StringHelper.isEmpty (fieldName))
     {
-      if (className.contains (" "))
+      if (className.contains (" ")) {
         return new PackageCreation (className.replaceAll (".* ", ""), options);
+      }
 
       return new ClassCreation (className, ec, options);
     }

--- a/plugin/generators/csv/src/main/java/com/helger/jcodemodel/plugin/generators/csv/CSVGenerator.java
+++ b/plugin/generators/csv/src/main/java/com/helger/jcodemodel/plugin/generators/csv/CSVGenerator.java
@@ -44,15 +44,14 @@ public class CSVGenerator extends AbstractFlatStructureGenerator
     fldSep = params.getOrDefault ("field_sep", fldSep);
   }
 
-  @SuppressWarnings("resource")
+  @SuppressWarnings ("resource")
   @Override
-  protected Stream<IFlatStructRecord> loadSource(final ISourcedInputStream source)
+  protected Stream <IFlatStructRecord> loadSource (final ISourcedInputStream source)
   {
     // What charset to use?
-    return new BufferedReader(new InputStreamReader(source.inputStream()))
-        .lines()
-        .map(this::convertLine)
-        .filter(r -> r != null);
+    return new BufferedReader (new InputStreamReader (source.inputStream ())).lines ()
+                                                                             .map (this::convertLine)
+                                                                             .filter (r -> r != null);
   }
 
   @Nullable
@@ -64,7 +63,8 @@ public class CSVGenerator extends AbstractFlatStructureGenerator
     }
     final String [] spl = line.trim ().split (fldSep);
     final String className = spl[0].trim ();
-    if (StringHelper.isEmpty (className)) {
+    if (StringHelper.isEmpty (className))
+    {
       return null;
     }
 
@@ -96,7 +96,8 @@ public class CSVGenerator extends AbstractFlatStructureGenerator
     // no field name specified : class or package definition
     if (StringHelper.isEmpty (fieldName))
     {
-      if (className.contains (" ")) {
+      if (className.contains (" "))
+      {
         return new PackageCreation (className.replaceAll (".* ", ""), options);
       }
 

--- a/plugin/generators/helloworld/src/main/java/com/helger/jcodemodel/plugin/generators/helloworld/HelloWorldGenerator.java
+++ b/plugin/generators/helloworld/src/main/java/com/helger/jcodemodel/plugin/generators/helloworld/HelloWorldGenerator.java
@@ -14,7 +14,6 @@
  */
 package com.helger.jcodemodel.plugin.generators.helloworld;
 
-import java.io.InputStream;
 import java.util.Map;
 
 import com.helger.jcodemodel.JCodeModel;
@@ -23,6 +22,7 @@ import com.helger.jcodemodel.JExpr;
 import com.helger.jcodemodel.JMod;
 import com.helger.jcodemodel.exceptions.JCodeModelException;
 import com.helger.jcodemodel.plugin.maven.ICodeModelBuilder;
+import com.helger.jcodemodel.plugin.maven.ISourcedInputStream;
 import com.helger.jcodemodel.plugin.maven.generators.JCMGen;
 
 @JCMGen
@@ -46,7 +46,7 @@ public class HelloWorldGenerator implements ICodeModelBuilder
   }
 
   @Override
-  public void build (final JCodeModel model, final InputStream source) throws JCodeModelException
+  public void build(final JCodeModel model, final ISourcedInputStream source) throws JCodeModelException
   {
     final JDefinedClass cl = model._class (expandClassName (className));
     if (m_sClassHeader != null && !m_sClassHeader.isBlank ())

--- a/plugin/generators/helloworld/src/main/java/com/helger/jcodemodel/plugin/generators/helloworld/HelloWorldGenerator.java
+++ b/plugin/generators/helloworld/src/main/java/com/helger/jcodemodel/plugin/generators/helloworld/HelloWorldGenerator.java
@@ -46,7 +46,7 @@ public class HelloWorldGenerator implements ICodeModelBuilder
   }
 
   @Override
-  public void build(final JCodeModel model, final ISourcedInputStream source) throws JCodeModelException
+  public void build (final JCodeModel model, final ISourcedInputStream source) throws JCodeModelException
   {
     final JDefinedClass cl = model._class (expandClassName (className));
     if (m_sClassHeader != null && !m_sClassHeader.isBlank ())

--- a/plugin/generators/json/src/main/java/com/helger/jcodemodel/plugin/generators/json/JsonGenerator.java
+++ b/plugin/generators/json/src/main/java/com/helger/jcodemodel/plugin/generators/json/JsonGenerator.java
@@ -15,13 +15,13 @@
 package com.helger.jcodemodel.plugin.generators.json;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Map.Entry;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.helger.jcodemodel.plugin.generators.json.parser.JsonField;
 import com.helger.jcodemodel.plugin.generators.json.parser.JsonPackage;
+import com.helger.jcodemodel.plugin.maven.ISourcedInputStream;
 import com.helger.jcodemodel.plugin.maven.generators.AbstractFlatStructureGenerator;
 import com.helger.jcodemodel.plugin.maven.generators.JCMGen;
 import com.helger.jcodemodel.plugin.maven.generators.flatstruct.FieldOptions;
@@ -36,7 +36,7 @@ public class JsonGenerator extends AbstractFlatStructureGenerator
 {
 
   @Override
-  protected Stream <IFlatStructRecord> loadSource (InputStream source)
+  protected Stream<IFlatStructRecord> loadSource(ISourcedInputStream source)
   {
     try
     {
@@ -48,10 +48,10 @@ public class JsonGenerator extends AbstractFlatStructureGenerator
     }
   }
 
-  protected JsonPackage load (InputStream source) throws IOException
+  protected JsonPackage load(ISourcedInputStream source) throws IOException
   {
     ObjectMapper mapper = new ObjectMapper ();
-    return mapper.readerFor (JsonPackage.class).readValue (source);
+    return mapper.readerFor(JsonPackage.class).readValue(source.inputStream());
   }
 
   protected Stream <IFlatStructRecord> visitPackage (JsonPackage pck, String path)

--- a/plugin/generators/json/src/main/java/com/helger/jcodemodel/plugin/generators/json/JsonGenerator.java
+++ b/plugin/generators/json/src/main/java/com/helger/jcodemodel/plugin/generators/json/JsonGenerator.java
@@ -36,7 +36,7 @@ public class JsonGenerator extends AbstractFlatStructureGenerator
 {
 
   @Override
-  protected Stream<IFlatStructRecord> loadSource(ISourcedInputStream source)
+  protected Stream <IFlatStructRecord> loadSource (ISourcedInputStream source)
   {
     try
     {
@@ -48,10 +48,10 @@ public class JsonGenerator extends AbstractFlatStructureGenerator
     }
   }
 
-  protected JsonPackage load(ISourcedInputStream source) throws IOException
+  protected JsonPackage load (ISourcedInputStream source) throws IOException
   {
     ObjectMapper mapper = new ObjectMapper ();
-    return mapper.readerFor(JsonPackage.class).readValue(source.inputStream());
+    return mapper.readerFor (JsonPackage.class).readValue (source.inputStream ());
   }
 
   protected Stream <IFlatStructRecord> visitPackage (JsonPackage pck, String path)

--- a/plugin/generators/yaml/src/main/java/com/helger/jcodemodel/plugin/generators/yaml/YamlGenerator.java
+++ b/plugin/generators/yaml/src/main/java/com/helger/jcodemodel/plugin/generators/yaml/YamlGenerator.java
@@ -14,7 +14,6 @@
  */
 package com.helger.jcodemodel.plugin.generators.yaml;
 
-
 import java.io.IOException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -25,12 +24,14 @@ import com.helger.jcodemodel.plugin.maven.ISourcedInputStream;
 import com.helger.jcodemodel.plugin.maven.generators.JCMGen;
 
 @JCMGen
-public class YamlGenerator extends JsonGenerator {
+public class YamlGenerator extends JsonGenerator
+{
 
   @Override
-  protected JsonPackage load(ISourcedInputStream source) throws IOException {
-    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-    return mapper.readerFor(JsonPackage.class).readValue(source.inputStream());
+  protected JsonPackage load (ISourcedInputStream source) throws IOException
+  {
+    ObjectMapper mapper = new ObjectMapper (new YAMLFactory ());
+    return mapper.readerFor (JsonPackage.class).readValue (source.inputStream ());
   }
 
 }

--- a/plugin/generators/yaml/src/main/java/com/helger/jcodemodel/plugin/generators/yaml/YamlGenerator.java
+++ b/plugin/generators/yaml/src/main/java/com/helger/jcodemodel/plugin/generators/yaml/YamlGenerator.java
@@ -16,21 +16,21 @@ package com.helger.jcodemodel.plugin.generators.yaml;
 
 
 import java.io.IOException;
-import java.io.InputStream;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.helger.jcodemodel.plugin.generators.json.JsonGenerator;
 import com.helger.jcodemodel.plugin.generators.json.parser.JsonPackage;
+import com.helger.jcodemodel.plugin.maven.ISourcedInputStream;
 import com.helger.jcodemodel.plugin.maven.generators.JCMGen;
 
 @JCMGen
 public class YamlGenerator extends JsonGenerator {
 
   @Override
-  protected JsonPackage load(InputStream source) throws IOException {
+  protected JsonPackage load(ISourcedInputStream source) throws IOException {
     ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-    return mapper.readerFor(JsonPackage.class).readValue(source);
+    return mapper.readerFor(JsonPackage.class).readValue(source.inputStream());
   }
 
 }

--- a/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/GenerateSourceMojo.java
+++ b/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/GenerateSourceMojo.java
@@ -15,13 +15,13 @@
 package com.helger.jcodemodel.plugin.maven;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -37,10 +37,12 @@ import org.apache.maven.project.MavenProject;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
-import com.helger.base.io.nonblocking.NonBlockingByteArrayInputStream;
 import com.helger.base.string.StringHelper;
 import com.helger.jcodemodel.JCodeModel;
 import com.helger.jcodemodel.exceptions.JCodeModelException;
+import com.helger.jcodemodel.plugin.maven.ISourcedInputStream.DirectSourced;
+import com.helger.jcodemodel.plugin.maven.ISourcedInputStream.FileSourced;
+import com.helger.jcodemodel.plugin.maven.ISourcedInputStream.URLSourced;
 import com.helger.jcodemodel.writer.JCMWriter;
 import com.helger.jcodemodel.writer.ProgressCodeWriter.IProgressTracker;
 
@@ -150,17 +152,17 @@ public class GenerateSourceMojo extends AbstractMojo
     {
       getLog ().warn ("discarding source param " + m_sSource + " as data is already set");
     }
-    Stream <? extends InputStream> sis = (StringHelper.isEmpty (m_sData)) ? findSources ()
-                                                                          : Stream.of (new NonBlockingByteArrayInputStream (m_sData.getBytes (StandardCharsets.UTF_8)));
-    for (InputStream is : sis.toList ())
+    List <ISourcedInputStream> sourcesList = (StringHelper.isEmpty (m_sData)) ? findSources ().toList ()
+                                                                              : List.of (new DirectSourced (m_sData));
+    for (ISourcedInputStream sourced : sourcesList)
     {
-      try (is)
+      try (InputStream is = sourced.inputStream ())
       {
         cmb.build (cm, is);
       }
       catch (JCodeModelException | IOException e)
       {
-        throw new MojoFailureException (e);
+        throw new MojoFailureException ("while applying source " + sourced, e);
       }
     }
     try
@@ -169,7 +171,7 @@ public class GenerateSourceMojo extends AbstractMojo
     }
     catch (IOException e)
     {
-      throw new MojoFailureException (e);
+      throw new MojoFailureException ("after applying sources " + sourcesList, e);
     }
   }
 
@@ -230,10 +232,10 @@ public class GenerateSourceMojo extends AbstractMojo
   /// @return extracted input streams if success, Stream of null if no source.
   /// @throws MojoExecutionException if can't open the source as a file nor an url.
   @NonNull
-  protected Stream <InputStream> findSources () throws MojoExecutionException
+  protected Stream <ISourcedInputStream> findSources () throws MojoExecutionException
   {
     if (m_sSource == null || m_sSource.isBlank ())
-      return Stream.of ((InputStream) null);
+      return Stream.of (ISourcedInputStream.NULL);
     // dumb checking : is it a file ? a URL ?
 
     // store the file exception, only show it if url also fails
@@ -252,7 +254,7 @@ public class GenerateSourceMojo extends AbstractMojo
     try
     {
       final URL aURL = new URL (m_sSource);
-      return Stream.of (aURL.openStream ());
+      return Stream.of (new URLSourced (m_sSource, aURL.openStream ()));
     }
     catch (final IOException e)
     {
@@ -272,13 +274,13 @@ public class GenerateSourceMojo extends AbstractMojo
    *         if it is a dir. Otherwise, return empty stream.
    */
   @NonNull
-  protected Stream <InputStream> streamFiles (File rootFile)
+  protected Stream <ISourcedInputStream> streamFiles (File rootFile)
   {
     if (rootFile.isFile ())
     {
       try
       {
-        return Stream.of (new FileInputStream (rootFile));
+        return Stream.of (new FileSourced (rootFile));
       }
       catch (FileNotFoundException e)
       {

--- a/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/GenerateSourceMojo.java
+++ b/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/GenerateSourceMojo.java
@@ -156,9 +156,10 @@ public class GenerateSourceMojo extends AbstractMojo
                                                                               : List.of (new DirectSourced (m_sData));
     for (ISourcedInputStream sourced : sourcesList)
     {
+      // specification accepts null closable, in that case it's not closed.
       try (InputStream is = sourced.inputStream ())
       {
-        cmb.build (cm, is);
+        cmb.build (cm, sourced);
       }
       catch (JCodeModelException | IOException e)
       {

--- a/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/ICodeModelBuilder.java
+++ b/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/ICodeModelBuilder.java
@@ -14,7 +14,6 @@
  */
 package com.helger.jcodemodel.plugin.maven;
 
-import java.io.InputStream;
 import java.util.Map;
 
 import org.jspecify.annotations.NonNull;
@@ -57,10 +56,10 @@ public interface ICodeModelBuilder
    * @throws JCodeModelException
    *         in case of creation error
    */
-  void build (JCodeModel model, @Nullable InputStream source) throws JCodeModelException;
+  void build (JCodeModel model, @NonNull ISourcedInputStream source) throws JCodeModelException;
 
   /**
-   * shortcut to {@link #build(JCodeModel, InputStream)} with null values.
+   * shortcut to {@link #build(JCodeModel, ISourcedInputStream)} with null values.
    *
    * @param model
    *        the model to build into.

--- a/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/ISourcedInputStream.java
+++ b/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/ISourcedInputStream.java
@@ -1,0 +1,57 @@
+package com.helger.jcodemodel.plugin.maven;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import com.helger.base.io.nonblocking.NonBlockingByteArrayInputStream;
+
+/// an inputstream and its source when it has one
+/// 
+/// implementations are :
+///  - from a file
+///  - from a url
+///  - transmitted directly
+///  - no source was provided, so null
+public sealed interface ISourcedInputStream
+{
+  public InputStream inputStream ();
+
+  /// when the inputstream is generated from a file
+  public static record FileSourced (File sourceFile, InputStream inputStream) implements ISourcedInputStream
+  {
+    public FileSourced (File sourceFile) throws FileNotFoundException
+    {
+      this (sourceFile, new FileInputStream (sourceFile));
+    }
+
+  }
+
+  /// when the inputstream is generated from a url
+  public static record URLSourced (String sourceUrl, InputStream inputStream) implements ISourcedInputStream
+  {}
+
+  /// when the data was transmitted directly
+  public static record DirectSourced (InputStream inputStream) implements ISourcedInputStream
+  {
+    public DirectSourced (String data)
+    {
+      this (new NonBlockingByteArrayInputStream (data.getBytes (StandardCharsets.UTF_8)));
+    }
+  }
+
+  /// when no data was provided, so no inputstream
+  public static record NullSourced () implements ISourcedInputStream
+  {
+    @Override
+    public InputStream inputStream ()
+    {
+      return null;
+    }
+  }
+
+  public static NullSourced NULL = new NullSourced ();
+
+}

--- a/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/generators/AbstractFlatStructureGenerator.java
+++ b/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/generators/AbstractFlatStructureGenerator.java
@@ -14,7 +14,6 @@
  */
 package com.helger.jcodemodel.plugin.maven.generators;
 
-import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -35,22 +34,10 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import com.helger.base.string.StringHelper;
-import com.helger.jcodemodel.AbstractJClass;
-import com.helger.jcodemodel.AbstractJType;
-import com.helger.jcodemodel.JBlock;
-import com.helger.jcodemodel.JCodeModel;
-import com.helger.jcodemodel.JDefinedClass;
-import com.helger.jcodemodel.JExpr;
-import com.helger.jcodemodel.JFieldVar;
-import com.helger.jcodemodel.JInvocation;
-import com.helger.jcodemodel.JMethod;
-import com.helger.jcodemodel.JMod;
-import com.helger.jcodemodel.JNarrowedClass;
-import com.helger.jcodemodel.JPrimitiveType;
-import com.helger.jcodemodel.JReferencedClass;
-import com.helger.jcodemodel.JVar;
+import com.helger.jcodemodel.*;
 import com.helger.jcodemodel.exceptions.JCodeModelException;
 import com.helger.jcodemodel.plugin.maven.ICodeModelBuilder;
+import com.helger.jcodemodel.plugin.maven.ISourcedInputStream;
 import com.helger.jcodemodel.plugin.maven.generators.flatstruct.ConcreteTypes;
 import com.helger.jcodemodel.plugin.maven.generators.flatstruct.EFieldOption;
 import com.helger.jcodemodel.plugin.maven.generators.flatstruct.EFieldVisibility;
@@ -90,7 +77,7 @@ public abstract class AbstractFlatStructureGenerator implements ICodeModelBuilde
    */
   private final Map <String, JFieldVar> classLastUpdated = new HashMap <> ();
 
-  protected abstract Stream <IFlatStructRecord> loadSource (@Nullable InputStream source);
+  protected abstract Stream <IFlatStructRecord> loadSource (@Nullable ISourcedInputStream source);
 
   public @Nullable String getClassHeader ()
   {
@@ -125,7 +112,7 @@ public abstract class AbstractFlatStructureGenerator implements ICodeModelBuilde
   }
 
   @Override
-  public void build (final JCodeModel model, final InputStream source) throws JCodeModelException
+  public void build (final JCodeModel model, final ISourcedInputStream source) throws JCodeModelException
   {
     final List <IFlatStructRecord> records = loadSource (source).toList ();
     createClasses (model, records);


### PR DESCRIPTION
Instead of getting a stream of inputstream, we also get their source information, if any. 

That source information is transmitted down to the generators, so they can use it, eg to deduce class name based on the file.

It is also printed on error, to know which file / url generated the issue.