### PR TITLE
JAtom int/long direct call to representation

### DIFF
--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomInt.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomInt.java
@@ -74,7 +74,7 @@ public class JAtomInt extends AIntegerRepresented <JAtomInt> implements IJExpres
 
   public void generate (@NonNull final IJFormatter f)
   {
-    f.print (representation.format (m_nValue));
+    f.print (representation ().base ().format (m_nValue, new StringBuilder (), representation ()).toString ());
   }
 
   @Override

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomLong.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/JAtomLong.java
@@ -74,7 +74,7 @@ public class JAtomLong extends AIntegerRepresented <JAtomLong> implements IJExpr
 
   public void generate (@NonNull final IJFormatter f)
   {
-    f.print (representation.format (m_nValue));
+    f.print (representation ().base ().format (m_nValue, new StringBuilder (), representation ()).toString ());
   }
 
   @Override

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/AIntegerRepresented.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/AIntegerRepresented.java
@@ -11,7 +11,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
 {
 
   @NonNull
-  protected IntegerRepresentation representation = IntegerRepresentation.DEFAULT;
+  protected IntegerRepresentation m_aRepresentation = IntegerRepresentation.DEFAULT;
 
   @SuppressWarnings ("unchecked")
   protected T self ()
@@ -22,7 +22,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   @NonNull
   public IntegerRepresentation representation ()
   {
-    return representation;
+    return m_aRepresentation;
   }
 
   /// change the internal representation to the provided one
@@ -32,7 +32,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   public @NonNull T representation (IntegerRepresentation representation)
   {
     if (representation != null)
-      this.representation = representation;
+      this.m_aRepresentation = representation;
     return self ();
   }
 
@@ -41,7 +41,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// @return this
   public @NonNull T positiveSign (boolean positiveSign)
   {
-    return representation (representation.positiveSign (positiveSign));
+    return representation (representation ().positiveSign (positiveSign));
   }
 
   /// change the internal representation to use binary base
@@ -49,7 +49,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// @return this
   public @NonNull T binary ()
   {
-    return representation (representation.base (EIntegerBase.BINARY));
+    return representation (representation ().base (EIntegerBase.BINARY));
   }
 
   /// change the internal representation to use decimal base
@@ -57,7 +57,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// @return this
   public @NonNull T decimal ()
   {
-    return representation (representation.base (EIntegerBase.DECIMAL));
+    return representation (representation ().base (EIntegerBase.DECIMAL));
   }
 
   /// change the internal representation to use hexadecimal base
@@ -65,7 +65,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// @return this
   public @NonNull T hexadecimal ()
   {
-    return representation (representation.base (EIntegerBase.HEXADECIMAL));
+    return representation (representation ().base (EIntegerBase.HEXADECIMAL));
   }
 
   /// change the internal representation to use octal base
@@ -73,7 +73,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// @return this
   public @NonNull T octal ()
   {
-    return representation (representation.base (EIntegerBase.OCTAL));
+    return representation (representation ().base (EIntegerBase.OCTAL));
   }
 
   /// change the internal representation to use a fixed separator size (the number of character
@@ -83,7 +83,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// @return this
   public @NonNull T separatorSize (int size)
   {
-    return representation (representation.separatorSize (size));
+    return representation (representation ().separatorSize (size));
   }
 
   /// change the internal representation to use a fixed separator distance (the maximum number of
@@ -93,7 +93,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// @return this
   public @NonNull T separateEvery (int every)
   {
-    return representation (representation.separateEvery (every));
+    return representation (representation ().separateEvery (every));
   }
 
   /// change the internal representation to use a padding value. The padding is not used for decimal
@@ -102,7 +102,7 @@ public abstract class AIntegerRepresented <T extends AIntegerRepresented <T>>
   /// @return this
   public @NonNull T padding (int padding)
   {
-    return representation (representation.padding (padding));
+    return representation (representation ().padding (padding));
   }
 
 }

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/EIntegerBase.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/EIntegerBase.java
@@ -61,7 +61,7 @@ public enum EIntegerBase
   }
 
   /// @return sb
-  public StringBuilder represent (int i,
+  public StringBuilder format (int i,
                                   StringBuilder sb,
                                   IntegerRepresentation f)
   {
@@ -83,7 +83,7 @@ public enum EIntegerBase
   }
 
   /// @return sb
-  public StringBuilder represent (long l,
+  public StringBuilder format (long l,
                                   StringBuilder sb,
                                   IntegerRepresentation f)
   {

--- a/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
+++ b/jcodemodel/src/main/java/com/helger/jcodemodel/literals/IntegerRepresentation.java
@@ -199,18 +199,4 @@ public record IntegerRepresentation (
     return suffixUpper == this.suffixUpper ? this : with (ir -> { ir.suffixUpper = suffixUpper; });
   }
 
-  //
-  // actual formatting is delegated to the base
-  //
-
-  public String format (int i)
-  {
-    return base.represent (i, new StringBuilder (), this).toString ();
-  }
-
-  public String format (long l)
-  {
-    return base.represent (l, new StringBuilder (), this).toString ();
-  }
-
 }


### PR DESCRIPTION
Basically the IntegerRepresentation is only the params. The EIntegerBase is the one doing the formatting.

also renamed "represent()" to "format()", more explicit

also renamed field representation to m_aRepresentation, using getter representation() instead.