### PR TITLE
maven plugin now concats data and source params streams.

### DIFF
--- a/plugin/generators/csv/src/main/java/com/helger/jcodemodel/plugin/generators/csv/CSVGenerator.java
+++ b/plugin/generators/csv/src/main/java/com/helger/jcodemodel/plugin/generators/csv/CSVGenerator.java
@@ -15,7 +15,6 @@
 package com.helger.jcodemodel.plugin.generators.csv;
 
 import java.io.BufferedReader;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -24,6 +23,7 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import com.helger.base.string.StringHelper;
+import com.helger.jcodemodel.plugin.maven.ISourcedInputStream;
 import com.helger.jcodemodel.plugin.maven.generators.AbstractFlatStructureGenerator;
 import com.helger.jcodemodel.plugin.maven.generators.JCMGen;
 import com.helger.jcodemodel.plugin.maven.generators.flatstruct.FieldOptions;
@@ -44,11 +44,14 @@ public class CSVGenerator extends AbstractFlatStructureGenerator
     fldSep = params.getOrDefault ("field_sep", fldSep);
   }
 
+  @SuppressWarnings ("resource")
   @Override
-  protected Stream <IFlatStructRecord> loadSource (final InputStream source)
+  protected Stream <IFlatStructRecord> loadSource (final ISourcedInputStream source)
   {
     // What charset to use?
-    return new BufferedReader (new InputStreamReader (source)).lines ().map (this::convertLine).filter (r -> r != null);
+    return new BufferedReader (new InputStreamReader (source.inputStream ())).lines ()
+                                                                             .map (this::convertLine)
+                                                                             .filter (r -> r != null);
   }
 
   @Nullable
@@ -61,7 +64,9 @@ public class CSVGenerator extends AbstractFlatStructureGenerator
     final String [] spl = line.trim ().split (fldSep);
     final String className = spl[0].trim ();
     if (StringHelper.isEmpty (className))
+    {
       return null;
+    }
 
     // field name for fields. Absent for non-fields
 
@@ -92,7 +97,9 @@ public class CSVGenerator extends AbstractFlatStructureGenerator
     if (StringHelper.isEmpty (fieldName))
     {
       if (className.contains (" "))
+      {
         return new PackageCreation (className.replaceAll (".* ", ""), options);
+      }
 
       return new ClassCreation (className, ec, options);
     }

--- a/plugin/generators/helloworld/src/main/java/com/helger/jcodemodel/plugin/generators/helloworld/HelloWorldGenerator.java
+++ b/plugin/generators/helloworld/src/main/java/com/helger/jcodemodel/plugin/generators/helloworld/HelloWorldGenerator.java
@@ -14,7 +14,6 @@
  */
 package com.helger.jcodemodel.plugin.generators.helloworld;
 
-import java.io.InputStream;
 import java.util.Map;
 
 import com.helger.jcodemodel.JCodeModel;
@@ -23,6 +22,7 @@ import com.helger.jcodemodel.JExpr;
 import com.helger.jcodemodel.JMod;
 import com.helger.jcodemodel.exceptions.JCodeModelException;
 import com.helger.jcodemodel.plugin.maven.ICodeModelBuilder;
+import com.helger.jcodemodel.plugin.maven.ISourcedInputStream;
 import com.helger.jcodemodel.plugin.maven.generators.JCMGen;
 
 @JCMGen
@@ -46,7 +46,7 @@ public class HelloWorldGenerator implements ICodeModelBuilder
   }
 
   @Override
-  public void build (final JCodeModel model, final InputStream source) throws JCodeModelException
+  public void build (final JCodeModel model, final ISourcedInputStream source) throws JCodeModelException
   {
     final JDefinedClass cl = model._class (expandClassName (className));
     if (m_sClassHeader != null && !m_sClassHeader.isBlank ())

--- a/plugin/generators/json/src/main/java/com/helger/jcodemodel/plugin/generators/json/JsonGenerator.java
+++ b/plugin/generators/json/src/main/java/com/helger/jcodemodel/plugin/generators/json/JsonGenerator.java
@@ -15,13 +15,13 @@
 package com.helger.jcodemodel.plugin.generators.json;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Map.Entry;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.helger.jcodemodel.plugin.generators.json.parser.JsonField;
 import com.helger.jcodemodel.plugin.generators.json.parser.JsonPackage;
+import com.helger.jcodemodel.plugin.maven.ISourcedInputStream;
 import com.helger.jcodemodel.plugin.maven.generators.AbstractFlatStructureGenerator;
 import com.helger.jcodemodel.plugin.maven.generators.JCMGen;
 import com.helger.jcodemodel.plugin.maven.generators.flatstruct.FieldOptions;
@@ -36,7 +36,7 @@ public class JsonGenerator extends AbstractFlatStructureGenerator
 {
 
   @Override
-  protected Stream <IFlatStructRecord> loadSource (InputStream source)
+  protected Stream <IFlatStructRecord> loadSource (ISourcedInputStream source)
   {
     try
     {
@@ -48,10 +48,10 @@ public class JsonGenerator extends AbstractFlatStructureGenerator
     }
   }
 
-  protected JsonPackage load (InputStream source) throws IOException
+  protected JsonPackage load (ISourcedInputStream source) throws IOException
   {
     ObjectMapper mapper = new ObjectMapper ();
-    return mapper.readerFor (JsonPackage.class).readValue (source);
+    return mapper.readerFor (JsonPackage.class).readValue (source.inputStream ());
   }
 
   protected Stream <IFlatStructRecord> visitPackage (JsonPackage pck, String path)

--- a/plugin/generators/yaml/src/main/java/com/helger/jcodemodel/plugin/generators/yaml/YamlGenerator.java
+++ b/plugin/generators/yaml/src/main/java/com/helger/jcodemodel/plugin/generators/yaml/YamlGenerator.java
@@ -14,23 +14,24 @@
  */
 package com.helger.jcodemodel.plugin.generators.yaml;
 
-
 import java.io.IOException;
-import java.io.InputStream;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.helger.jcodemodel.plugin.generators.json.JsonGenerator;
 import com.helger.jcodemodel.plugin.generators.json.parser.JsonPackage;
+import com.helger.jcodemodel.plugin.maven.ISourcedInputStream;
 import com.helger.jcodemodel.plugin.maven.generators.JCMGen;
 
 @JCMGen
-public class YamlGenerator extends JsonGenerator {
+public class YamlGenerator extends JsonGenerator
+{
 
   @Override
-  protected JsonPackage load(InputStream source) throws IOException {
-    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-    return mapper.readerFor(JsonPackage.class).readValue(source);
+  protected JsonPackage load (ISourcedInputStream source) throws IOException
+  {
+    ObjectMapper mapper = new ObjectMapper (new YAMLFactory ());
+    return mapper.readerFor (JsonPackage.class).readValue (source.inputStream ());
   }
 
 }

--- a/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/GenerateSourceMojo.java
+++ b/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/GenerateSourceMojo.java
@@ -44,9 +44,29 @@ import com.helger.jcodemodel.exceptions.JCodeModelException;
 import com.helger.jcodemodel.writer.JCMWriter;
 import com.helger.jcodemodel.writer.ProgressCodeWriter.IProgressTracker;
 
+/// This mojo does the following :
+/// 
+/// 1. deduce the output folder and ensure it is present. If [m_sOutputDir] is null or blank then default "src/generated/java" is used.
+/// 2. deduce the generator to be used. If [m_sGenerator] is null or blank, then loads the resource [GENERATOR_CLASS_FILE] instead.
+/// 3. instantiate the generator class and configure it, create a new JCM to modify.
+/// 4. list the data to apply the generator to.
+///    If provided, [m_sData] is passed.
+///    If [m_sSource] is a file, it is opened ; if it is a directory, its children are opened, after being filtered by [sourcesFilter] if non null.
+///    If [m_sSource] is a url, it is opened.
+///    If no data and no source provided, then null is returned as data.
+/// 5. apply the generator on each data separately, modifying the JCM.
+/// 6. export the JCM
+/// 
+/// Note that the plugin does not actually generate code by itself : the generator used is responsible for modifying the JCM.
+/// 
+/// The simplest way to make it work as a plugin, is to add a single auto executing generator as a dependency.
+/// This way the generator will be discovered and loaded automatically, you just need to configure its data/source, if any.  
+/// 
 @Mojo (name = "generate-source", threadSafe = true, defaultPhase = LifecyclePhase.GENERATE_SOURCES)
 public class GenerateSourceMojo extends AbstractMojo
 {
+
+  /// generated/parsed generator description file
   public static final String GENERATOR_CLASS_FILE = "jcodemodel/plugin/generator";
 
   /**
@@ -146,12 +166,8 @@ public class GenerateSourceMojo extends AbstractMojo
       cmb.configure (m_aParams);
 
     final JCodeModel cm = new JCodeModel ();
-    if (m_sData != null && !m_sData.isBlank () && m_sSource != null && !m_sSource.isBlank ())
-    {
-      getLog ().warn ("discarding source param " + m_sSource + " as data is already set");
-    }
-    Stream <? extends InputStream> sis = (StringHelper.isEmpty (m_sData)) ? findSources ()
-                                                                          : Stream.of (new NonBlockingByteArrayInputStream (m_sData.getBytes (StandardCharsets.UTF_8)));
+
+    Stream <? extends InputStream> sis = findSources ();
     for (InputStream is : sis.toList ())
     {
       try (is)
@@ -219,22 +235,29 @@ public class GenerateSourceMojo extends AbstractMojo
     }
   }
 
-  /// Extract the inputstreams from the specified source.
+  /// Extract the inputstreams from the specified data/source. At least one inputstream is
+  /// contained, unless an error happens.
   ///
-  /// - null is returned as a stream containing null
+  /// - if data is set, it is appended at the top ; then the source is processed
+  /// - null/blank source produces null inputstream, if data is not set ; ignored otherwise.
   /// - A directory string is recursively streamed over its files
   /// - A single file String is opened as a single-element stream
-  /// - A url string is opened it as a stream
-  /// - otherwise, as for example file not found, exception is thrown
+  /// - A url string is opened as a stream
+  /// - otherwise, as for example url not found, an exception is thrown
   ///
   /// @return extracted input streams if success, Stream of null if no source.
   /// @throws MojoExecutionException if can't open the source as a file nor an url.
   @NonNull
   protected Stream <InputStream> findSources () throws MojoExecutionException
   {
+    InputStream fromRawData = (StringHelper.isEmpty (m_sData)) ? null
+                                                               : new NonBlockingByteArrayInputStream (m_sData.getBytes (StandardCharsets.UTF_8));
     if (m_sSource == null || m_sSource.isBlank ())
-      return Stream.of ((InputStream) null);
-    // dumb checking : is it a file ? a URL ?
+      return Stream.of (fromRawData);
+
+    //
+    // dumb checking the source : is it a file ? a URL ?
+    //
 
     // store the file exception, only show it if url also fails
     Exception fileException = null;
@@ -242,7 +265,8 @@ public class GenerateSourceMojo extends AbstractMojo
     {
       final File aTargetFile = m_sSource.startsWith ("/") ? new File (m_sSource)
                                                           : new File (m_aProject.getBasedir (), m_sSource);
-      return streamFiles (aTargetFile);
+      if (aTargetFile.exists ())
+        return Stream.concat (fromRawData == null ? Stream.of () : Stream.of (fromRawData), streamFiles (aTargetFile));
     }
     catch (final Exception e)
     {
@@ -252,14 +276,14 @@ public class GenerateSourceMojo extends AbstractMojo
     try
     {
       final URL aURL = new URL (m_sSource);
-      return Stream.of (aURL.openStream ());
+      return fromRawData == null ? Stream.of (aURL.openStream ()) : Stream.of (fromRawData, aURL.openStream ());
     }
     catch (final IOException e)
     {
-      getLog ().error ("while trying to open " + m_sSource + " as a file", fileException);
+      if (fileException != null)
+        getLog ().error ("while trying to open " + m_sSource + " as a file", fileException);
       getLog ().error ("while trying to open " + m_sSource + " as a url", e);
     }
-
     throw new MojoExecutionException ("could not open provided source " + m_sSource + " as a file or url");
   }
 
@@ -295,9 +319,7 @@ public class GenerateSourceMojo extends AbstractMojo
         return Stream.of (rootFile.listFiles ())
                      .filter (f -> sourcesFilter == null ||
                        sourcesFilter.isBlank () ||
-                       f.getName ()
-                        .toLowerCase (Locale.ROOT)
-                        .contains (sourcesFilter.toLowerCase (Locale.ROOT)))
+                       f.getName ().toLowerCase (Locale.ROOT).contains (sourcesFilter.toLowerCase (Locale.ROOT)))
                      .sorted (Comparator.comparing (File::getPath))
                      .flatMap (this::streamFiles);
   }

--- a/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/GenerateSourceMojo.java
+++ b/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/GenerateSourceMojo.java
@@ -15,13 +15,13 @@
 package com.helger.jcodemodel.plugin.maven;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -37,10 +37,12 @@ import org.apache.maven.project.MavenProject;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
-import com.helger.base.io.nonblocking.NonBlockingByteArrayInputStream;
 import com.helger.base.string.StringHelper;
 import com.helger.jcodemodel.JCodeModel;
 import com.helger.jcodemodel.exceptions.JCodeModelException;
+import com.helger.jcodemodel.plugin.maven.ISourcedInputStream.DirectSourced;
+import com.helger.jcodemodel.plugin.maven.ISourcedInputStream.FileSourced;
+import com.helger.jcodemodel.plugin.maven.ISourcedInputStream.URLSourced;
 import com.helger.jcodemodel.writer.JCMWriter;
 import com.helger.jcodemodel.writer.ProgressCodeWriter.IProgressTracker;
 
@@ -150,17 +152,18 @@ public class GenerateSourceMojo extends AbstractMojo
     {
       getLog ().warn ("discarding source param " + m_sSource + " as data is already set");
     }
-    Stream <? extends InputStream> sis = (StringHelper.isEmpty (m_sData)) ? findSources ()
-                                                                          : Stream.of (new NonBlockingByteArrayInputStream (m_sData.getBytes (StandardCharsets.UTF_8)));
-    for (InputStream is : sis.toList ())
+    List <ISourcedInputStream> sourcesList = (StringHelper.isEmpty (m_sData)) ? findSources ().toList ()
+                                                                              : List.of (new DirectSourced (m_sData));
+    for (ISourcedInputStream sourced : sourcesList)
     {
-      try (is)
+      // specification accepts null closable, in that case it's not closed.
+      try (InputStream is = sourced.inputStream ())
       {
-        cmb.build (cm, is);
+        cmb.build (cm, sourced);
       }
       catch (JCodeModelException | IOException e)
       {
-        throw new MojoFailureException (e);
+        throw new MojoFailureException ("while applying source " + sourced, e);
       }
     }
     try
@@ -169,7 +172,7 @@ public class GenerateSourceMojo extends AbstractMojo
     }
     catch (IOException e)
     {
-      throw new MojoFailureException (e);
+      throw new MojoFailureException ("after applying sources " + sourcesList, e);
     }
   }
 
@@ -230,10 +233,10 @@ public class GenerateSourceMojo extends AbstractMojo
   /// @return extracted input streams if success, Stream of null if no source.
   /// @throws MojoExecutionException if can't open the source as a file nor an url.
   @NonNull
-  protected Stream <InputStream> findSources () throws MojoExecutionException
+  protected Stream <ISourcedInputStream> findSources () throws MojoExecutionException
   {
     if (m_sSource == null || m_sSource.isBlank ())
-      return Stream.of ((InputStream) null);
+      return Stream.of (ISourcedInputStream.NULL);
     // dumb checking : is it a file ? a URL ?
 
     // store the file exception, only show it if url also fails
@@ -252,7 +255,7 @@ public class GenerateSourceMojo extends AbstractMojo
     try
     {
       final URL aURL = new URL (m_sSource);
-      return Stream.of (aURL.openStream ());
+      return Stream.of (new URLSourced (m_sSource, aURL.openStream ()));
     }
     catch (final IOException e)
     {
@@ -272,13 +275,13 @@ public class GenerateSourceMojo extends AbstractMojo
    *         if it is a dir. Otherwise, return empty stream.
    */
   @NonNull
-  protected Stream <InputStream> streamFiles (File rootFile)
+  protected Stream <ISourcedInputStream> streamFiles (File rootFile)
   {
     if (rootFile.isFile ())
     {
       try
       {
-        return Stream.of (new FileInputStream (rootFile));
+        return Stream.of (new FileSourced (rootFile));
       }
       catch (FileNotFoundException e)
       {

--- a/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/ICodeModelBuilder.java
+++ b/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/ICodeModelBuilder.java
@@ -14,7 +14,6 @@
  */
 package com.helger.jcodemodel.plugin.maven;
 
-import java.io.InputStream;
 import java.util.Map;
 
 import org.jspecify.annotations.NonNull;
@@ -57,10 +56,10 @@ public interface ICodeModelBuilder
    * @throws JCodeModelException
    *         in case of creation error
    */
-  void build (JCodeModel model, @Nullable InputStream source) throws JCodeModelException;
+  void build (JCodeModel model, @NonNull ISourcedInputStream source) throws JCodeModelException;
 
   /**
-   * shortcut to {@link #build(JCodeModel, InputStream)} with null values.
+   * shortcut to {@link #build(JCodeModel, ISourcedInputStream)} with null values.
    *
    * @param model
    *        the model to build into.

--- a/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/ICodeModelBuilder.java
+++ b/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/ICodeModelBuilder.java
@@ -58,19 +58,6 @@ public interface ICodeModelBuilder
    */
   void build (JCodeModel model, @NonNull ISourcedInputStream source) throws JCodeModelException;
 
-  /**
-   * shortcut to {@link #build(JCodeModel, ISourcedInputStream)} with null values.
-   *
-   * @param model
-   *        the model to build into.
-   * @throws JCodeModelException
-   *         in case of creation error
-   */
-  default void build (final JCodeModel model) throws JCodeModelException
-  {
-    build (model, null);
-  }
-
   @Nullable
   String getRootPackage ();
 

--- a/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/ISourcedInputStream.java
+++ b/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/ISourcedInputStream.java
@@ -1,0 +1,57 @@
+package com.helger.jcodemodel.plugin.maven;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import com.helger.base.io.nonblocking.NonBlockingByteArrayInputStream;
+
+/// an inputstream and its source when it has one
+/// 
+/// implementations are :
+///  - from a file
+///  - from a url
+///  - transmitted directly
+///  - no source was provided, so null
+public sealed interface ISourcedInputStream
+{
+  public InputStream inputStream ();
+
+  /// when the inputstream is generated from a file
+  public static record FileSourced (File sourceFile, InputStream inputStream) implements ISourcedInputStream
+  {
+    public FileSourced (File sourceFile) throws FileNotFoundException
+    {
+      this (sourceFile, new FileInputStream (sourceFile));
+    }
+
+  }
+
+  /// when the inputstream is generated from a url
+  public static record URLSourced (String sourceUrl, InputStream inputStream) implements ISourcedInputStream
+  {}
+
+  /// when the data was transmitted directly
+  public static record DirectSourced (InputStream inputStream) implements ISourcedInputStream
+  {
+    public DirectSourced (String data)
+    {
+      this (new NonBlockingByteArrayInputStream (data.getBytes (StandardCharsets.UTF_8)));
+    }
+  }
+
+  /// when no data was provided, so no inputstream
+  public static record NullSourced () implements ISourcedInputStream
+  {
+    @Override
+    public InputStream inputStream ()
+    {
+      return null;
+    }
+  }
+
+  public static NullSourced NULL = new NullSourced ();
+
+}

--- a/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/generators/AbstractFlatStructureGenerator.java
+++ b/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/generators/AbstractFlatStructureGenerator.java
@@ -14,7 +14,6 @@
  */
 package com.helger.jcodemodel.plugin.maven.generators;
 
-import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -35,22 +34,10 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import com.helger.base.string.StringHelper;
-import com.helger.jcodemodel.AbstractJClass;
-import com.helger.jcodemodel.AbstractJType;
-import com.helger.jcodemodel.JBlock;
-import com.helger.jcodemodel.JCodeModel;
-import com.helger.jcodemodel.JDefinedClass;
-import com.helger.jcodemodel.JExpr;
-import com.helger.jcodemodel.JFieldVar;
-import com.helger.jcodemodel.JInvocation;
-import com.helger.jcodemodel.JMethod;
-import com.helger.jcodemodel.JMod;
-import com.helger.jcodemodel.JNarrowedClass;
-import com.helger.jcodemodel.JPrimitiveType;
-import com.helger.jcodemodel.JReferencedClass;
-import com.helger.jcodemodel.JVar;
+import com.helger.jcodemodel.*;
 import com.helger.jcodemodel.exceptions.JCodeModelException;
 import com.helger.jcodemodel.plugin.maven.ICodeModelBuilder;
+import com.helger.jcodemodel.plugin.maven.ISourcedInputStream;
 import com.helger.jcodemodel.plugin.maven.generators.flatstruct.ConcreteTypes;
 import com.helger.jcodemodel.plugin.maven.generators.flatstruct.EFieldOption;
 import com.helger.jcodemodel.plugin.maven.generators.flatstruct.EFieldVisibility;
@@ -90,7 +77,7 @@ public abstract class AbstractFlatStructureGenerator implements ICodeModelBuilde
    */
   private final Map <String, JFieldVar> classLastUpdated = new HashMap <> ();
 
-  protected abstract Stream <IFlatStructRecord> loadSource (@Nullable InputStream source);
+  protected abstract Stream <IFlatStructRecord> loadSource (@Nullable ISourcedInputStream source);
 
   public @Nullable String getClassHeader ()
   {
@@ -125,7 +112,7 @@ public abstract class AbstractFlatStructureGenerator implements ICodeModelBuilde
   }
 
   @Override
-  public void build (final JCodeModel model, final InputStream source) throws JCodeModelException
+  public void build (final JCodeModel model, final ISourcedInputStream source) throws JCodeModelException
   {
     final List <IFlatStructRecord> records = loadSource (source).toList ();
     createClasses (model, records);


### PR DESCRIPTION
STATUS : stale
A potential issue with using stream of URL arose, a security check needs to be performed

---

Previously, in the plugin params, if "data" was set then "source" was ignored ; now they are both used, providing several inputstreams to apply the generator against.

If none are present, the plugin still resolves a Stream.of(null) : this way a generator which does not need data would still work (is called against a null inputstream), while a generator that requires data would fail (throwing NPE) rather than be silently skipped.

Also fixes the plugin not trying to fetch the source as an url, and showing errors when no error happened.

Also fixes the plugin silently skipping when the source could not be loaded.

This was possible after the patch listing the children when the source is a directory, as this patch enabled having several sources.