### PR TITLE
fix null inputstream behavior

### DIFF
--- a/examples/plugins/helloworld/pom.xml
+++ b/examples/plugins/helloworld/pom.xml
@@ -64,6 +64,7 @@ limitations under the License.
             <configuration>
               <generator>com.helger.jcodemodel.plugin.generators.helloworld.HelloWorldGenerator2</generator>
               <outputDir>src/generated/java2</outputDir>
+              <data>useless data</data>
               <params>
                 <name>Hello2</name>
                 <value>world2</value>

--- a/plugin/generators/csv/src/main/java/com/helger/jcodemodel/plugin/generators/csv/CSVGenerator.java
+++ b/plugin/generators/csv/src/main/java/com/helger/jcodemodel/plugin/generators/csv/CSVGenerator.java
@@ -64,7 +64,10 @@ public class CSVGenerator extends AbstractFlatStructureGenerator
   {
     final InputStream is = source.inputStream ();
     if (is == null)
-      return Stream.empty ();
+      throw new IllegalArgumentException ("generator " +
+                                          getClass ().getSimpleName () +
+                                          " needs to receive inputstream, received " +
+                                          source);
 
     return new BufferedReader (new InputStreamReader (is, charset)).lines ()
                                                                    .map (this::convertLine)

--- a/plugin/generators/csv/src/main/java/com/helger/jcodemodel/plugin/generators/csv/CSVGenerator.java
+++ b/plugin/generators/csv/src/main/java/com/helger/jcodemodel/plugin/generators/csv/CSVGenerator.java
@@ -25,6 +25,8 @@ import java.util.stream.Stream;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.helger.base.string.StringHelper;
 import com.helger.jcodemodel.plugin.maven.ISourcedInputStream;
@@ -40,6 +42,9 @@ import com.helger.jcodemodel.plugin.maven.generators.flatstruct.IFlatStructRecor
 @JCMGen
 public class CSVGenerator extends AbstractFlatStructureGenerator
 {
+
+  private static final Logger log = LoggerFactory.getLogger (CSVGenerator.class);
+
   /// charset the source is read with, when the "charset" parameter is not set
   public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 
@@ -64,10 +69,14 @@ public class CSVGenerator extends AbstractFlatStructureGenerator
   {
     final InputStream is = source.inputStream ();
     if (is == null)
-      throw new IllegalArgumentException ("generator " +
-                                          getClass ().getSimpleName () +
-                                          " needs to receive inputstream, received " +
-                                          source);
+    {
+      log.warn ("generator " +
+                getClass ().getSimpleName () +
+                " did not receive a valid source, received " +
+                source +
+                " instead");
+      return Stream.empty ();
+    }
 
     return new BufferedReader (new InputStreamReader (is, charset)).lines ()
                                                                    .map (this::convertLine)

--- a/plugin/generators/helloworld/src/main/java/com/helger/jcodemodel/plugin/generators/helloworld/HelloWorldGenerator.java
+++ b/plugin/generators/helloworld/src/main/java/com/helger/jcodemodel/plugin/generators/helloworld/HelloWorldGenerator.java
@@ -16,6 +16,9 @@ package com.helger.jcodemodel.plugin.generators.helloworld;
 
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.helger.jcodemodel.JCodeModel;
 import com.helger.jcodemodel.JDefinedClass;
 import com.helger.jcodemodel.JExpr;
@@ -28,6 +31,9 @@ import com.helger.jcodemodel.plugin.maven.generators.JCMGen;
 @JCMGen
 public class HelloWorldGenerator implements ICodeModelBuilder
 {
+
+  private static final Logger log = LoggerFactory.getLogger (HelloWorldGenerator.class);
+
   protected String m_sRootPackage = "com.helger.tests.helloworld";
   private String m_sClassHeader = "";
   protected String className = "Hello";
@@ -48,6 +54,14 @@ public class HelloWorldGenerator implements ICodeModelBuilder
   @Override
   public void build (final JCodeModel model, final ISourcedInputStream source) throws JCodeModelException
   {
+    if (source != ISourcedInputStream.NULL)
+    {
+      log.warn ("generator " +
+                getClass ().getSimpleName () +
+                " received a source " +
+                source +
+                " which is discarded. If multiple sources are provided, this may lead to runtime error");
+    }
     final JDefinedClass cl = model._class (expandClassName (className));
     if (m_sClassHeader != null && !m_sClassHeader.isBlank ())
     {

--- a/plugin/generators/json/src/main/java/com/helger/jcodemodel/plugin/generators/json/JsonGenerator.java
+++ b/plugin/generators/json/src/main/java/com/helger/jcodemodel/plugin/generators/json/JsonGenerator.java
@@ -23,6 +23,8 @@ import java.util.Map.Entry;
 import java.util.stream.Stream;
 
 import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.helger.jcodemodel.plugin.generators.json.parser.JsonField;
@@ -41,15 +43,21 @@ import com.helger.jcodemodel.plugin.maven.generators.flatstruct.IFlatStructRecor
 public class JsonGenerator extends AbstractFlatStructureGenerator
 {
 
+  private static final Logger log = LoggerFactory.getLogger (JsonGenerator.class);
+
   @Override
   protected Stream <IFlatStructRecord> loadSource (@NonNull final ISourcedInputStream source)
   {
     final InputStream is = source.inputStream ();
     if (is == null)
-      throw new IllegalArgumentException ("generator " +
-                                          getClass ().getSimpleName () +
-                                          " needs to receive inputstream, received " +
-                                          source);
+    {
+      log.warn ("generator " +
+                getClass ().getSimpleName () +
+                " did not receive a valid source, received " +
+                source +
+                " instead");
+      return Stream.empty ();
+    }
 
     try
     {

--- a/plugin/generators/json/src/main/java/com/helger/jcodemodel/plugin/generators/json/JsonGenerator.java
+++ b/plugin/generators/json/src/main/java/com/helger/jcodemodel/plugin/generators/json/JsonGenerator.java
@@ -46,7 +46,10 @@ public class JsonGenerator extends AbstractFlatStructureGenerator
   {
     final InputStream is = source.inputStream ();
     if (is == null)
-      return Stream.empty ();
+      throw new IllegalArgumentException ("generator " +
+                                          getClass ().getSimpleName () +
+                                          " needs to receive inputstream, received " +
+                                          source);
 
     try
     {

--- a/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/GenerateSourceMojo.java
+++ b/plugin/plugin/src/main/java/com/helger/jcodemodel/plugin/maven/GenerateSourceMojo.java
@@ -297,6 +297,8 @@ public class GenerateSourceMojo extends AbstractMojo
         ret.add (buildSource (cmb, cm, openURLSource ()));
       }
     }
+    if (ret.isEmpty ())
+      ret.add (buildSource (cmb, cm, ISourcedInputStream.NULL));
     return ret;
   }
 


### PR DESCRIPTION

 - ensures the generator receives at least one SourcedInputStream (NULL if none actually transmitted)
 - helloworldgenerator prints a warning when it receives a non null source (as if several are received, it will apply several times to the JCM with the same params and this leads to error when creating the same class twice). The example has a data set to show this works :) 
 - csv and json generators print a warning if the inputstream is null. They are designed to work against a source, so not receiving a source to work against may be an issue.